### PR TITLE
feat: track watch prices from Swiss Time House

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DropHunter is a Python-powered Discord game price tracker. It monitors game prices via the [IsThereAnyDeal API](https://isthereanydeal.com/), uses [Groq](https://groq.com/) (Llama-3) for AI-driven buy recommendations via function calling, persists state in Supabase (PostgreSQL), runs background price sweeps via a cron daemon, and delivers notifications via Discord.
+DropHunter is a Python-powered Discord game and watch price tracker. It monitors game prices via the [IsThereAnyDeal API](https://isthereanydeal.com/) and watch prices from Swiss Time House product pages (fetched with `cloudscraper` to pass Cloudflare, parsed from `schema.org` Product JSON-LD), uses [Groq](https://groq.com/) (Llama-3) for AI-driven buy recommendations via function calling, persists state in Supabase (PostgreSQL), runs background price sweeps via a cron daemon, and delivers notifications via Discord.
 
 **Phase 1 is complete.** Phase 2 targets LangGraph-based agentic rewrite, conversational memory, custom target pricing, and Langfuse observability. See `docs/superpowers/plans/2026-04-05-drophunter-phase-2-roadmap.md`.
 
@@ -14,10 +14,10 @@ DropHunter is a Python-powered Discord game price tracker. It monitors game pric
 ai/           # AIProvider ABC + Groq and Gemini provider implementations
 bot/          # Discord bot client and tool function definitions
 cron/         # Background price sweep daemon (price_check.py)
-db/           # Supabase client and schema.sql (games, price_history, notifications_log)
+db/           # Supabase client and schema.sql (game + watch tables, chat memory)
 docs/         # Architectural specs and roadmap plans
 tests/        # Pytest unit tests
-utils/        # ITAD API helpers and Discord webhook utilities
+utils/        # ITAD API helpers, Swiss Time House watch fetcher (watches.py), Discord webhook utilities
 main.py       # Discord bot entrypoint
 pyproject.toml
 ```
@@ -48,8 +48,8 @@ ruff format .
 
 - **Entry point:** `main.py` starts the Discord bot, which listens for user messages and dispatches them to the AI layer.
 - **AI layer (`ai/`):** `AIProvider` is an abstract base class. `groq_provider.py` implements Groq/Llama-3 tool calling with a self-healing fallback for malformed LLM responses. `gemini_provider.py` is an alternative provider.
-- **Bot layer (`bot/`):** Discord bot client (`bot/client.py`) handles events. `bot/functions.py` defines the tools exposed to the LLM (`add_game`, `list_games`, `get_current_price`, `get_recent_deals`).
-- **Database (`db/`):** Supabase/PostgreSQL via `db/client.py`. Schema has three tables: `games` (watchlist), `price_history`, `notifications_log`. See `db/schema.sql`.
-- **Scheduler (`cron/`):** `cron/price_check.py` runs as a background daemon — sweeps tracked games, compares against historical lows, fires Discord webhook alerts with AI commentary. Also triggered via GitHub Actions.
-- **Notifications (`utils/`):** `utils/discord.py` sends webhook messages. `utils/itad.py` wraps the ITAD v3 API, querying the `IN` (India) region and returning INR (₹) prices across up to 10 storefronts.
+- **Bot layer (`bot/`):** Discord bot client (`bot/client.py`) handles events. `bot/functions.py` defines the tools exposed to the LLM — game tools (`add_game`, `list_games`, `get_current_price`, `get_recent_deals`) and watch tools (`add_watch`, `list_watches`, `get_watch_price`, `set_watch_target`, `remove_watch`).
+- **Database (`db/`):** Supabase/PostgreSQL via `db/client.py`. Game tables: `games` (watchlist), `price_history`, `notifications_log`. Watch tables: `watches`, `watch_price_history`, `watch_notifications_log`. Plus chat memory (`chat_messages`, `chat_summary`). See `db/schema.sql`.
+- **Scheduler (`cron/`):** `cron/price_check.py` runs as a background daemon — `process_game` sweeps tracked games (compares against historical lows) and `process_watch` sweeps tracked watches (compares the lowest available price against the watch's required target). Both fire Discord webhook alerts with AI commentary. Also triggered via GitHub Actions.
+- **Notifications (`utils/`):** `utils/discord.py` sends webhook messages (`send_deal_alert` for games, `send_watch_alert` for watches). `utils/itad.py` wraps the ITAD v3 API (`IN` region, INR). `utils/watches.py` fetches Swiss Time House product pages via `cloudscraper` (Cloudflare bypass) and parses the embedded `schema.org` Product JSON-LD into `{name, brand, reference, price}`.
 - **Environment variables:** `ITAD_API_KEY`, `GROQ_API_KEY`, `DISCORD_TOKEN`, `DISCORD_WEBHOOK_URL`, `SUPABASE_URL`, `SUPABASE_KEY` — use `.env` locally; GitHub Actions secrets in CI.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DropHunter
 
-A personal Discord bot that tracks game prices and alerts you when deals hit. Built as an AI agent — you talk to it in plain English and it handles the rest.
+A personal Discord bot that tracks game and watch prices and alerts you when deals hit. Built as an AI agent — you talk to it in plain English and it handles the rest.
 <img width="2442" height="1423" alt="image" src="https://github.com/user-attachments/assets/023ac522-b964-4e54-9fda-0fc24faded6f" />
 
 ---
@@ -8,6 +8,7 @@ A personal Discord bot that tracks game prices and alerts you when deals hit. Bu
 ## What it does
 
 - **Track games** — tell the bot to watch a game and it monitors prices across all storefronts via [IsThereAnyDeal](https://isthereanydeal.com/)
+- **Track watches** — paste a [Swiss Time House](https://www.swisstimehouse.com) product URL and set a target price; the bot fetches the listing (past Cloudflare via `cloudscraper`, parsing the page's `schema.org` Product JSON-LD) and alerts you when the price drops to/below your target
 - **Custom price targets** — set a threshold (e.g. "alert me when Elden Ring drops below ₹500") instead of waiting for the all-time low
 - **Daily price sweeps** — a background cron job checks every tracked game and fires a Discord webhook alert with AI commentary when a deal is found
 - **Conversational memory** — the bot remembers your conversation across sessions using Supabase-backed chat history and rolling summarization
@@ -31,7 +32,7 @@ Discord message
   └── save_memory       persist turn, rolling summarization via Gemini
       │
       ▼
- cron/price_check.py    background daemon — sweeps all tracked games daily
+ cron/price_check.py    background daemon — sweeps all tracked games and watches daily
       │
       ▼
  utils/discord.py       webhook alert with Groq AI commentary
@@ -39,7 +40,7 @@ Discord message
 
 **AI layer:** `GroqProvider` (primary) + `GeminiProvider` (fallback). Both implement the `AIProvider` ABC. The `_FallbackProvider` wrapper auto-switches on failure.
 
-**Database:** Supabase (PostgreSQL) with four tables — `games`, `price_history`, `notifications_log`, `chat_messages`, `chat_summary`.
+**Database:** Supabase (PostgreSQL) — game tables (`games`, `price_history`, `notifications_log`), watch tables (`watches`, `watch_price_history`, `watch_notifications_log`), and chat memory (`chat_messages`, `chat_summary`).
 
 **Observability:** Full end-to-end tracing via [Langfuse](https://langfuse.com/) — every conversation produces a trace with child spans per graph node, LLM generations with token counts, and per-tool spans.
 
@@ -57,6 +58,11 @@ Discord message
 | "what's the historical low for Celeste?" | all-time low from ITAD |
 | "show recent deals" | last notified deals |
 | "set target for Elden Ring to ₹800" | updates price threshold |
+| "track this watch https://www.swisstimehouse.com/casio-g1714 under ₹30000" | adds a watch with a target price |
+| "what watches am I tracking?" | lists tracked watches with targets |
+| "what's the price of my Casio G1714?" | live price from Swiss Time House |
+| "set watch target for Casio G1714 to ₹28000" | updates the watch threshold |
+| "stop tracking the Casio G1714" | removes the watch |
 
 ---
 
@@ -67,7 +73,8 @@ Discord message
 | Bot | discord.py |
 | AI | Groq (Llama-3.3-70b-versatile), Google Gemini (gemini-3-flash-preview) |
 | Agent framework | LangGraph |
-| Prices | IsThereAnyDeal API v3 (IN region, INR) |
+| Game prices | IsThereAnyDeal API v3 (IN region, INR) |
+| Watch prices | Swiss Time House product pages (`cloudscraper` + BeautifulSoup, `schema.org` JSON-LD) |
 | Database | Supabase (PostgreSQL) |
 | Observability | Langfuse v3 |
 | Hosting | Render (Web Service) |
@@ -83,7 +90,7 @@ ai/           AIProvider ABC, GroqProvider, GeminiProvider, LangGraph graph
 bot/          Discord client, tool function definitions
 cron/         Background price sweep daemon
 db/           Supabase client, schema.sql
-utils/        ITAD API helpers, Discord webhook sender
+utils/        ITAD API helpers, Swiss Time House watch fetcher, Discord webhook sender
 tests/        Pytest unit tests
 main.py       Entrypoint — starts bot + health check HTTP server
 Dockerfile    Python 3.11-slim image

--- a/ai/graph.py
+++ b/ai/graph.py
@@ -24,9 +24,13 @@ logger = logging.getLogger("drophunter.graph")
 MAX_TOOL_ITERATIONS = 7
 
 _SYSTEM_PROMPT = (
-    "You are DropHunter, a personal game deal assistant. "
-    "When the user asks you to track, untrack, list games, check prices, see recent deals, "
+    "You are DropHunter, a personal deal assistant for games and watches. "
+    "For games: when the user asks to track, untrack, list games, check prices, see recent deals, "
     "check historical lows, or set target prices, use the available tools. "
+    "For watches: the user tracks a watch by giving a swisstimehouse.com product URL. "
+    "Use add_watch with the URL; a target price in INR is required, so if the user hasn't given "
+    "one, add_watch will report the current price and you should ask them for a target. "
+    "Use list_watches, get_watch_price, set_watch_target, and remove_watch for watch management. "
     "You can call multiple tools in sequence if needed. "
     "For anything else, respond helpfully in plain text."
 )

--- a/bot/functions.py
+++ b/bot/functions.py
@@ -1,6 +1,7 @@
 import logging
 
 from db.client import (
+    _find_watch_by_name as db_find_watch_by_name,
     add_game as db_add_game,
     add_watch as db_add_watch,
     clear_memory as db_clear_memory,
@@ -153,13 +154,7 @@ def list_watches() -> str:
 
 def get_watch_price(name: str) -> str:
     logger.info("get_watch_price called: name=%s", name)
-    watches = db_get_watches()
-    from db.client import _normalize
-    norm = _normalize(name)
-    match = next(
-        (w for w in watches if norm in _normalize(w["name"]) or _normalize(w["name"]) in norm),
-        None,
-    )
+    match = db_find_watch_by_name(name)
     if not match or not match.get("swisstimehouse_url"):
         return f"**{name}** isn't on your watch list."
     fetched = fetch_swisstimehouse(match["swisstimehouse_url"])

--- a/bot/functions.py
+++ b/bot/functions.py
@@ -2,14 +2,19 @@ import logging
 
 from db.client import (
     add_game as db_add_game,
+    add_watch as db_add_watch,
     clear_memory as db_clear_memory,
     force_summarize as db_force_summarize,
     get_games as db_get_games,
     get_recent_deals as db_get_recent_deals,
+    get_watches as db_get_watches,
     remove_game as db_remove_game,
+    remove_watch as db_remove_watch,
     set_target_price as db_set_target_price,
+    set_watch_target as db_set_watch_target,
 )
 from utils.itad import get_all_prices, get_historical_low, search_game
+from utils.watches import fetch_swisstimehouse
 
 logger = logging.getLogger("drophunter.functions")
 
@@ -104,6 +109,79 @@ def get_recent_deals() -> str:
         for d in deals
     )
     return f"**Recent deals I found:**\n{lines}"
+
+
+def add_watch(url: str, target_price: float = None) -> str:
+    logger.info("add_watch called: url=%s, target_price=%s", url, target_price)
+    watch = fetch_swisstimehouse(url)
+    if watch is None:
+        return (
+            "Sorry, I couldn't read a price from that link. "
+            "Make sure it's a swisstimehouse.com product page."
+        )
+    if target_price is None:
+        return (
+            f"**{watch['name']}** is currently ₹{watch['price']:.2f} on Swiss Time House. "
+            f"What target price (in ₹) should I alert you below?"
+        )
+    db_add_watch(
+        name=watch["name"],
+        brand=watch["brand"],
+        reference_no=watch["reference"],
+        target_price=target_price,
+        swisstimehouse_url=url,
+    )
+    return (
+        f"Tracking **{watch['name']}** (currently ₹{watch['price']:.2f}). "
+        f"I'll alert you when it drops below ₹{target_price:.2f}."
+    )
+
+
+def list_watches() -> str:
+    logger.info("list_watches called")
+    watches = db_get_watches()
+    if not watches:
+        return "Your watch list is empty. Add one with a swisstimehouse.com product link."
+    lines = ["**Watches you're tracking:**"]
+    for w in watches:
+        line = f"• {w['name']}"
+        if w.get("target_price") is not None:
+            line += f" (target: ₹{float(w['target_price']):.2f})"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def get_watch_price(name: str) -> str:
+    logger.info("get_watch_price called: name=%s", name)
+    watches = db_get_watches()
+    from db.client import _normalize
+    norm = _normalize(name)
+    match = next(
+        (w for w in watches if norm in _normalize(w["name"]) or _normalize(w["name"]) in norm),
+        None,
+    )
+    if not match or not match.get("swisstimehouse_url"):
+        return f"**{name}** isn't on your watch list."
+    fetched = fetch_swisstimehouse(match["swisstimehouse_url"])
+    if fetched is None:
+        return f"I couldn't fetch the current price for **{match['name']}** right now."
+    return f"**{match['name']}** is currently ₹{fetched['price']:.2f} on Swiss Time House."
+
+
+def set_watch_target(name: str, target_price: float) -> str:
+    logger.info("set_watch_target called: name=%s, target_price=%s", name, target_price)
+    updated = db_set_watch_target(name, target_price)
+    if not updated:
+        return f"**{name}** wasn't found in your watch list."
+    return f"Target price for **{name}** set to ₹{target_price:.2f}."
+
+
+def remove_watch(name: str) -> str:
+    logger.info("remove_watch called: name=%s", name)
+    removed = db_remove_watch(name)
+    if removed:
+        return f"No longer tracking **{name}**."
+    return f"**{name}** wasn't in your watch list."
 
 
 # Tool definitions in OpenAI function-calling format
@@ -234,6 +312,82 @@ TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_watch",
+            "description": (
+                "Track a watch's price from a swisstimehouse.com product URL. "
+                "Provide a target price in INR; the user is alerted when the price drops below it. "
+                "If no target price is given, this returns the current price and asks for one."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "A swisstimehouse.com product page URL.",
+                    },
+                    "target_price": {
+                        "type": "number",
+                        "description": "Target alert price in INR.",
+                    },
+                },
+                "required": ["url"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_watches",
+            "description": "List all watches currently being tracked.",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_watch_price",
+            "description": "Get the current price of a tracked watch from swisstimehouse.com.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the tracked watch."}
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_watch_target",
+            "description": "Set or update the target price (INR) for a tracked watch.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the tracked watch."},
+                    "target_price": {"type": "number", "description": "New target price in INR."},
+                },
+                "required": ["name", "target_price"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "remove_watch",
+            "description": "Remove a watch from the watch list.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the watch to remove."}
+                },
+                "required": ["name"],
+            },
+        },
+    },
 ]
 
 
@@ -254,6 +408,11 @@ _FUNCTION_MAP = {
     "set_target_price": set_target_price,
     "get_historical_low_price": get_historical_low_price,
     "clear_memory": clear_memory,
+    "add_watch": add_watch,
+    "list_watches": list_watches,
+    "get_watch_price": get_watch_price,
+    "set_watch_target": set_watch_target,
+    "remove_watch": remove_watch,
 }
 
 

--- a/cron/price_check.py
+++ b/cron/price_check.py
@@ -4,11 +4,16 @@ from ai import get_provider
 from db.client import (
     get_games,
     get_last_notified_price,
+    get_last_watch_notified_price,
+    get_watches,
     insert_price_history,
+    insert_watch_price_history,
     log_notification,
+    log_watch_notification,
 )
-from utils.discord import send_deal_alert
+from utils.discord import send_deal_alert, send_watch_alert
 from utils.itad import get_best_price, get_historical_low
+from utils.watches import fetch_swisstimehouse
 
 logger = logging.getLogger("drophunter.cron")
 
@@ -91,6 +96,62 @@ def process_game(game: dict) -> None:
     logger.info("[%s] Deal alert sent!", title)
 
 
+_SWISS_SELLER = "Swiss Time House"
+
+
+def process_watch(watch: dict) -> None:
+    name = watch["name"]
+    logger.info("[%s] Fetching watch price...", name)
+
+    swiss_price = None
+    url = watch.get("swisstimehouse_url")
+    if url:
+        fetched = fetch_swisstimehouse(url)
+        if fetched is not None:
+            swiss_price = fetched["price"]
+
+    insert_watch_price_history(
+        watch_id=watch["id"], swisstimehouse_price=swiss_price, myntra_price=None
+    )
+
+    # Lowest available price across sources (only swisstimehouse in v1).
+    candidates = [(swiss_price, _SWISS_SELLER)]
+    available = [(p, s) for p, s in candidates if p is not None]
+    if not available:
+        logger.info("[%s] No price available this sweep, skipping.", name)
+        return
+
+    price, seller = min(available, key=lambda ps: ps[0])
+    target = float(watch["target_price"])
+    if price > target:
+        logger.info("[%s] ₹%.2f above target ₹%.2f, skipping.", name, price, target)
+        return
+
+    last_notified = get_last_watch_notified_price(watch["id"])
+    if last_notified is not None and price >= last_notified:
+        logger.info(
+            "[%s] ₹%.2f not lower than last notified ₹%.2f, skipping.",
+            name, price, last_notified,
+        )
+        return
+
+    logger.info("[%s] Deal! ₹%.2f on %s. Generating commentary...", name, price, seller)
+    provider = get_provider()
+    commentary = provider.generate_text(
+        f"Write a one-sentence buy recommendation for the watch '{name}'. "
+        f"Current price: ₹{price} on {seller}, below the user's target of ₹{target}."
+    )
+    send_watch_alert(
+        watch_name=name,
+        price=price,
+        seller=seller,
+        target_price=target,
+        ai_commentary=commentary,
+    )
+    log_watch_notification(watch["id"], price, seller)
+    logger.info("[%s] Watch alert sent!", name)
+
+
 def run() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -105,6 +166,14 @@ def run() -> None:
             process_game(game)
         except Exception as exc:
             logger.error("[%s] ERROR: %s", game["title"], exc, exc_info=True)
+
+    watches = get_watches()
+    logger.info("Checking prices for %d watch(es)...", len(watches))
+    for watch in watches:
+        try:
+            process_watch(watch)
+        except Exception as exc:
+            logger.error("[%s] ERROR: %s", watch["name"], exc, exc_info=True)
     logger.info("Price check run complete.")
 
 

--- a/cron/price_check.py
+++ b/cron/price_check.py
@@ -105,7 +105,9 @@ def process_watch(watch: dict) -> None:
 
     swiss_price = None
     url = watch.get("swisstimehouse_url")
-    if url:
+    if not url:
+        logger.warning("[%s] No swisstimehouse_url configured, skipping fetch.", name)
+    else:
         fetched = fetch_swisstimehouse(url)
         if fetched is not None:
             swiss_price = fetched["price"]

--- a/db/client.py
+++ b/db/client.py
@@ -355,3 +355,125 @@ def clear_memory(user_id: str) -> None:
     _get_client().table("chat_messages").delete().eq("user_id", user_id).execute()
     _get_client().table("chat_summary").delete().eq("user_id", user_id).execute()
     logger.info("Cleared all memory for user %s", user_id)
+
+
+# ---------------------------------------------------------------------------
+# Watch helpers
+# ---------------------------------------------------------------------------
+
+def get_watches() -> list:
+    logger.debug("Fetching all watches")
+    return _get_client().table("watches").select("*").execute().data
+
+
+def add_watch(
+    name: str,
+    brand: Optional[str],
+    reference_no: Optional[str],
+    target_price: float,
+    swisstimehouse_url: str,
+) -> dict:
+    logger.info("Adding watch: %s (target=%s, url=%s)", name, target_price, swisstimehouse_url)
+    row = {
+        "name": name,
+        "brand": brand,
+        "reference_no": reference_no,
+        "target_price": target_price,
+        "swisstimehouse_url": swisstimehouse_url,
+    }
+    result = (
+        _get_client().table("watches").upsert(row, on_conflict="swisstimehouse_url").execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watches' returned no data: {result}")
+    return result.data[0]
+
+
+def _find_watch_by_name(name: str) -> Optional[dict]:
+    """Fuzzy-match a watch by name, reusing the same normalization as games."""
+    norm_query = _normalize(name)
+    watches = get_watches()
+    for w in watches:
+        if _normalize(w["name"]) == norm_query:
+            return w
+    for w in watches:
+        if norm_query in _normalize(w["name"]) or _normalize(w["name"]) in norm_query:
+            return w
+    return None
+
+
+def set_watch_target(name: str, target_price: float) -> bool:
+    watch = _find_watch_by_name(name)
+    if not watch:
+        logger.warning("No watch matched '%s' for target update", name)
+        return False
+    result = (
+        _get_client()
+        .table("watches")
+        .update({"target_price": target_price})
+        .eq("id", watch["id"])
+        .execute()
+    )
+    return len(result.data) > 0
+
+
+def remove_watch(name: str) -> bool:
+    watch = _find_watch_by_name(name)
+    if not watch:
+        logger.warning("No watch matched '%s' for removal", name)
+        return False
+    result = _get_client().table("watches").delete().eq("id", watch["id"]).execute()
+    return len(result.data) > 0
+
+
+def insert_watch_price_history(
+    watch_id: str,
+    swisstimehouse_price: Optional[float],
+    myntra_price: Optional[float] = None,
+) -> dict:
+    result = (
+        _get_client()
+        .table("watch_price_history")
+        .insert(
+            {
+                "watch_id": watch_id,
+                "swisstimehouse_price": swisstimehouse_price,
+                "myntra_price": myntra_price,
+            }
+        )
+        .execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watch_price_history' returned no data: {result}")
+    return result.data[0]
+
+
+def get_last_watch_notified_price(watch_id: str) -> Optional[float]:
+    result = (
+        _get_client()
+        .table("watch_notifications_log")
+        .select("price")
+        .eq("watch_id", watch_id)
+        .order("notified_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if not result.data:
+        return None
+    return float(result.data[0]["price"])
+
+
+def log_watch_notification(watch_id: str, price: float, seller: str) -> dict:
+    logger.info(
+        "Logging watch notification: watch_id=%s price=%.2f seller=%s",
+        watch_id, price, seller,
+    )
+    result = (
+        _get_client()
+        .table("watch_notifications_log")
+        .insert({"watch_id": watch_id, "price": price, "seller": seller})
+        .execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watch_notifications_log' returned no data: {result}")
+    return result.data[0]

--- a/db/client.py
+++ b/db/client.py
@@ -386,6 +386,7 @@ def add_watch(
     )
     if not result.data:
         raise RuntimeError(f"Insert into 'watches' returned no data: {result}")
+    logger.info("Watch added/updated: %s", name)
     return result.data[0]
 
 
@@ -403,6 +404,7 @@ def _find_watch_by_name(name: str) -> Optional[dict]:
 
 
 def set_watch_target(name: str, target_price: float) -> bool:
+    logger.info("Setting watch target for %s: %s", name, target_price)
     watch = _find_watch_by_name(name)
     if not watch:
         logger.warning("No watch matched '%s' for target update", name)
@@ -423,6 +425,7 @@ def remove_watch(name: str) -> bool:
         logger.warning("No watch matched '%s' for removal", name)
         return False
     result = _get_client().table("watches").delete().eq("id", watch["id"]).execute()
+    logger.info("Watch removed: %s", watch["name"])
     return len(result.data) > 0
 
 
@@ -449,6 +452,7 @@ def insert_watch_price_history(
 
 
 def get_last_watch_notified_price(watch_id: str) -> Optional[float]:
+    """Return the price from the most recent notification for this watch, or None."""
     result = (
         _get_client()
         .table("watch_notifications_log")

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,3 +43,33 @@ create table if not exists chat_summary (
 );
 
 create index if not exists idx_chat_messages_user_id on chat_messages(user_id);
+
+create table if not exists watches (
+    id uuid primary key default gen_random_uuid(),
+    name text not null,
+    brand text null,
+    reference_no text null,
+    target_price numeric not null,
+    swisstimehouse_url text null unique,
+    myntra_url text null,
+    added_at timestamptz not null default now()
+);
+
+create table if not exists watch_price_history (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    swisstimehouse_price numeric null,
+    myntra_price numeric null,
+    fetched_at timestamptz not null default now()
+);
+
+create table if not exists watch_notifications_log (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    price numeric not null,
+    seller text not null,
+    notified_at timestamptz not null default now()
+);
+
+create index if not exists idx_watch_price_history_watch_id on watch_price_history(watch_id);
+create index if not exists idx_watch_notifications_log_watch_id on watch_notifications_log(watch_id);

--- a/docs/superpowers/plans/2026-05-30-watch-tracking.md
+++ b/docs/superpowers/plans/2026-05-30-watch-tracking.md
@@ -1,0 +1,1248 @@
+# Watch Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users track watch prices from swisstimehouse.com by URL with a required target price, and fire a Discord alert when the price drops to/below target — running as a parallel path alongside the existing game tracker.
+
+**Architecture:** A parallel "watch" path that mirrors the game path but swaps the price source. Watches are fetched with `cloudscraper` (swisstimehouse is behind Cloudflare) and parsed from the page's embedded `schema.org` JSON-LD. Three new DB tables (`watches`, `watch_price_history`, `watch_notifications_log`) leave the game tables untouched. The schema carries `myntra_*` columns reserved for a future source, but only swisstimehouse is implemented now.
+
+**Tech Stack:** Python 3.11, Supabase (PostgreSQL), `cloudscraper` + `beautifulsoup4` (new), pytest + pytest-mock, LangGraph/Groq/Gemini (existing AI layer), Discord webhooks.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-watch-tracking-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `utils/watches.py` — `fetch_swisstimehouse(url)`: cloudscraper fetch + JSON-LD parse. Single responsibility: turn a swisstimehouse URL into `{name, brand, reference, price}` or `None`.
+- `tests/test_watches.py` — tests for `fetch_swisstimehouse` against a saved HTML fixture.
+- `tests/fixtures/swisstimehouse_casio_g1714.html` — saved real product page HTML for deterministic parser tests.
+
+**Modify:**
+- `db/schema.sql` — add the three `watch*` tables.
+- `db/client.py` — watch CRUD + price-history + notification helpers.
+- `bot/functions.py` — `add_watch` / `list_watches` / `get_watch_price` / `set_watch_target` / `remove_watch`, registered in `TOOLS` and `_FUNCTION_MAP`.
+- `utils/discord.py` — `send_watch_alert(...)`.
+- `cron/price_check.py` — `process_watch(watch)` + watch loop in `run()`.
+- `ai/graph.py` — extend `_SYSTEM_PROMPT` to mention watch tracking.
+- `requirements.txt` — add `cloudscraper`, `beautifulsoup4`.
+
+**Test files (modify/add):**
+- `tests/test_watches.py`, `tests/test_db.py`, `tests/test_bot_functions.py`, `tests/test_cron.py`, `tests/test_discord_webhook.py`.
+
+---
+
+## Task 1: Add dependencies
+
+**Files:**
+- Modify: `requirements.txt`
+
+- [ ] **Step 1: Add the two new dependencies**
+
+Append these two lines to `requirements.txt` (after `tenacity==8.5.0`, keeping existing entries):
+
+```
+cloudscraper==1.2.71
+beautifulsoup4==4.12.3
+```
+
+- [ ] **Step 2: Install them**
+
+Run: `pip install cloudscraper==1.2.71 beautifulsoup4==4.12.3`
+Expected: `Successfully installed ... cloudscraper-1.2.71 ... beautifulsoup4-4.12.3 ...`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add requirements.txt
+git commit -m "build: add cloudscraper and beautifulsoup4 for watch tracking"
+```
+
+---
+
+## Task 2: Save a real swisstimehouse HTML fixture
+
+A real fixture makes the parser test deterministic and offline. We save the live page once.
+
+**Files:**
+- Create: `tests/fixtures/swisstimehouse_casio_g1714.html`
+
+- [ ] **Step 1: Download the live page via cloudscraper into the fixture**
+
+Run:
+
+```bash
+mkdir -p tests/fixtures
+python -c "import cloudscraper; open('tests/fixtures/swisstimehouse_casio_g1714.html','w').write(cloudscraper.create_scraper().get('https://www.swisstimehouse.com/casio-g1714', timeout=30).text)"
+```
+
+Expected: command exits 0 and the file is created.
+
+- [ ] **Step 2: Verify the fixture contains the JSON-LD Product price**
+
+Run: `grep -c '"@type": "Product"' tests/fixtures/swisstimehouse_casio_g1714.html`
+Expected: a number `>= 1` (the page has at least one `Product` JSON-LD block).
+
+Run: `grep -o '"price": *"\?34997' tests/fixtures/swisstimehouse_casio_g1714.html | head -1`
+Expected: a match like `"price": 34997` or `"price": "34997"`.
+
+> If the live price has changed since this plan was written, that is fine — note the **actual** integer price you see in the fixture and use it as the expected value in Task 3's test instead of `34997`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/fixtures/swisstimehouse_casio_g1714.html
+git commit -m "test: add swisstimehouse product page fixture"
+```
+
+---
+
+## Task 3: `utils/watches.py` — fetch + parse
+
+**Files:**
+- Create: `utils/watches.py`
+- Test: `tests/test_watches.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_watches.py`:
+
+```python
+# tests/test_watches.py
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "swisstimehouse_casio_g1714.html"
+
+
+def _mock_scraper_returning(html: str):
+    """Build a fake cloudscraper whose .get(...) returns a response with .text=html."""
+    response = MagicMock()
+    response.text = html
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    scraper = MagicMock()
+    scraper.get.return_value = response
+    return scraper
+
+
+def test_fetch_swisstimehouse_parses_jsonld():
+    from utils.watches import fetch_swisstimehouse
+
+    html = FIXTURE.read_text()
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=_mock_scraper_returning(html)):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+
+    assert result is not None
+    assert result["brand"] == "Casio"
+    assert result["reference"] == "G1714"
+    assert "Casio" in result["name"]
+    assert result["price"] == 34997.0
+    assert isinstance(result["price"], float)
+
+
+def test_fetch_swisstimehouse_rejects_non_swisstimehouse_url():
+    from utils.watches import fetch_swisstimehouse
+
+    result = fetch_swisstimehouse("https://www.amazon.in/some-watch")
+    assert result is None
+
+
+def test_fetch_swisstimehouse_returns_none_when_no_product_jsonld():
+    from utils.watches import fetch_swisstimehouse
+
+    html = "<html><head><title>nope</title></head><body>no structured data</body></html>"
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=_mock_scraper_returning(html)):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+    assert result is None
+
+
+def test_fetch_swisstimehouse_returns_none_on_request_error():
+    from utils.watches import fetch_swisstimehouse
+
+    scraper = MagicMock()
+    scraper.get.side_effect = Exception("Cloudflare blocked")
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_watches.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'utils.watches'`.
+
+- [ ] **Step 3: Implement `utils/watches.py`**
+
+Create `utils/watches.py`:
+
+```python
+import json
+import logging
+from urllib.parse import urlparse
+
+import cloudscraper
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger("drophunter.watches")
+
+_ALLOWED_HOST = "swisstimehouse.com"
+
+
+def _is_swisstimehouse(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host == _ALLOWED_HOST or host.endswith("." + _ALLOWED_HOST)
+
+
+def _extract_product_jsonld(html: str) -> dict | None:
+    """Return the first schema.org Product JSON-LD object with a price, or None."""
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = script.string or script.get_text() or ""
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        candidates = data if isinstance(data, list) else [data]
+        for obj in candidates:
+            if not isinstance(obj, dict):
+                continue
+            if obj.get("@type") != "Product":
+                continue
+            offers = obj.get("offers") or {}
+            if isinstance(offers, list):
+                offers = offers[0] if offers else {}
+            if offers.get("price") is None:
+                continue
+            return obj
+    return None
+
+
+def fetch_swisstimehouse(url: str) -> dict | None:
+    """
+    Fetch a swisstimehouse.com product page and parse its schema.org JSON-LD.
+    Returns {name, brand, reference, price} or None on any failure.
+    """
+    if not _is_swisstimehouse(url):
+        logger.warning("Rejecting non-swisstimehouse URL: %s", url)
+        return None
+
+    try:
+        scraper = cloudscraper.create_scraper()
+        response = scraper.get(url, timeout=30)
+        response.raise_for_status()
+        html = response.text
+    except Exception as exc:
+        logger.warning("Failed to fetch swisstimehouse URL %s: %s", url, exc)
+        return None
+
+    product = _extract_product_jsonld(html)
+    if product is None:
+        logger.warning("No Product JSON-LD with a price found at %s", url)
+        return None
+
+    offers = product.get("offers") or {}
+    if isinstance(offers, list):
+        offers = offers[0] if offers else {}
+
+    brand = product.get("brand") or {}
+    brand_name = brand.get("name") if isinstance(brand, dict) else brand
+
+    result = {
+        "name": product.get("name"),
+        "brand": brand_name,
+        "reference": product.get("sku") or product.get("mpn"),
+        "price": float(offers["price"]),
+    }
+    logger.info(
+        "Fetched %s: %s (ref=%s) ₹%.2f",
+        url, result["name"], result["reference"], result["price"],
+    )
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_watches.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check utils/watches.py tests/test_watches.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/watches.py tests/test_watches.py
+git commit -m "feat: add fetch_swisstimehouse with cloudscraper + JSON-LD parsing"
+```
+
+---
+
+## Task 4: Database schema — watch tables
+
+**Files:**
+- Modify: `db/schema.sql`
+
+- [ ] **Step 1: Append the watch tables to `db/schema.sql`**
+
+Add at the end of `db/schema.sql`:
+
+```sql
+create table if not exists watches (
+    id uuid primary key default gen_random_uuid(),
+    name text not null,
+    brand text null,
+    reference_no text null,
+    target_price numeric not null,
+    swisstimehouse_url text null unique,
+    myntra_url text null,
+    added_at timestamptz not null default now()
+);
+
+create table if not exists watch_price_history (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    swisstimehouse_price numeric null,
+    myntra_price numeric null,
+    fetched_at timestamptz not null default now()
+);
+
+create table if not exists watch_notifications_log (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    price numeric not null,
+    seller text not null,
+    notified_at timestamptz not null default now()
+);
+
+create index if not exists idx_watch_price_history_watch_id on watch_price_history(watch_id);
+create index if not exists idx_watch_notifications_log_watch_id on watch_notifications_log(watch_id);
+```
+
+- [ ] **Step 2: Apply the schema to Supabase**
+
+Run this SQL in the Supabase SQL editor (or via the project's existing migration path). This is a manual/operational step — `db/schema.sql` is the source of truth for the tables; there is no automated migration runner in this repo.
+Expected: three tables created, no errors. Verify with: `select count(*) from watches;` → returns `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/schema.sql
+git commit -m "feat: add watches, watch_price_history, watch_notifications_log tables"
+```
+
+---
+
+## Task 5: DB client — watch CRUD helpers
+
+**Files:**
+- Modify: `db/client.py`
+- Test: `tests/test_db.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_db.py`:
+
+```python
+def test_add_watch_upserts(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    fake_table.upsert.return_value.execute.return_value.data = [{"id": "w1", "name": "Casio G1714"}]
+    mocker.patch.object(client, "_get_client", return_value=mocker.MagicMock(table=lambda *_: fake_table))
+
+    result = client.add_watch(
+        name="Casio G1714", brand="Casio", reference_no="G1714",
+        target_price=30000.0, swisstimehouse_url="https://www.swisstimehouse.com/casio-g1714",
+    )
+    assert result["id"] == "w1"
+    fake_table.upsert.assert_called_once()
+    args, kwargs = fake_table.upsert.call_args
+    assert kwargs.get("on_conflict") == "swisstimehouse_url"
+    assert args[0]["target_price"] == 30000.0
+
+
+def test_get_watches_returns_rows(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    fake_table.select.return_value.execute.return_value.data = [{"id": "w1", "name": "Casio G1714"}]
+    mocker.patch.object(client, "_get_client", return_value=mocker.MagicMock(table=lambda *_: fake_table))
+
+    rows = client.get_watches()
+    assert rows == [{"id": "w1", "name": "Casio G1714"}]
+
+
+def test_set_watch_target_updates_match(mocker):
+    from db import client
+
+    mocker.patch.object(client, "get_watches", return_value=[{"id": "w1", "name": "Casio G1714"}])
+    fake_table = mocker.MagicMock()
+    fake_table.update.return_value.eq.return_value.execute.return_value.data = [{"id": "w1"}]
+    mocker.patch.object(client, "_get_client", return_value=mocker.MagicMock(table=lambda *_: fake_table))
+
+    assert client.set_watch_target("casio g1714", 25000.0) is True
+
+
+def test_set_watch_target_no_match(mocker):
+    from db import client
+
+    mocker.patch.object(client, "get_watches", return_value=[])
+    assert client.set_watch_target("nonexistent", 25000.0) is False
+
+
+def test_remove_watch_deletes_match(mocker):
+    from db import client
+
+    mocker.patch.object(client, "get_watches", return_value=[{"id": "w1", "name": "Casio G1714"}])
+    fake_table = mocker.MagicMock()
+    fake_table.delete.return_value.eq.return_value.execute.return_value.data = [{"id": "w1"}]
+    mocker.patch.object(client, "_get_client", return_value=mocker.MagicMock(table=lambda *_: fake_table))
+
+    assert client.remove_watch("Casio G1714") is True
+
+
+def test_get_last_watch_notified_price(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    chain = fake_table.select.return_value.eq.return_value.order.return_value.limit.return_value
+    chain.execute.return_value.data = [{"price": 28000}]
+    mocker.patch.object(client, "_get_client", return_value=mocker.MagicMock(table=lambda *_: fake_table))
+
+    assert client.get_last_watch_notified_price("w1") == 28000.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_db.py -k watch -v`
+Expected: FAIL — `AttributeError: module 'db.client' has no attribute 'add_watch'` (and similar).
+
+- [ ] **Step 3: Implement the helpers in `db/client.py`**
+
+Append to `db/client.py`:
+
+```python
+def get_watches() -> list:
+    logger.debug("Fetching all watches")
+    return _get_client().table("watches").select("*").execute().data
+
+
+def add_watch(
+    name: str,
+    brand: Optional[str],
+    reference_no: Optional[str],
+    target_price: float,
+    swisstimehouse_url: str,
+) -> dict:
+    logger.info("Adding watch: %s (target=%s, url=%s)", name, target_price, swisstimehouse_url)
+    row = {
+        "name": name,
+        "brand": brand,
+        "reference_no": reference_no,
+        "target_price": target_price,
+        "swisstimehouse_url": swisstimehouse_url,
+    }
+    result = (
+        _get_client().table("watches").upsert(row, on_conflict="swisstimehouse_url").execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watches' returned no data: {result}")
+    return result.data[0]
+
+
+def _find_watch_by_name(name: str) -> Optional[dict]:
+    """Fuzzy-match a watch by name, reusing the same normalization as games."""
+    norm_query = _normalize(name)
+    watches = get_watches()
+    for w in watches:
+        if _normalize(w["name"]) == norm_query:
+            return w
+    for w in watches:
+        if norm_query in _normalize(w["name"]) or _normalize(w["name"]) in norm_query:
+            return w
+    return None
+
+
+def set_watch_target(name: str, target_price: float) -> bool:
+    watch = _find_watch_by_name(name)
+    if not watch:
+        logger.warning("No watch matched '%s' for target update", name)
+        return False
+    result = (
+        _get_client().table("watches").update({"target_price": target_price}).eq("id", watch["id"]).execute()
+    )
+    return len(result.data) > 0
+
+
+def remove_watch(name: str) -> bool:
+    watch = _find_watch_by_name(name)
+    if not watch:
+        logger.warning("No watch matched '%s' for removal", name)
+        return False
+    result = _get_client().table("watches").delete().eq("id", watch["id"]).execute()
+    return len(result.data) > 0
+
+
+def insert_watch_price_history(
+    watch_id: str,
+    swisstimehouse_price: Optional[float],
+    myntra_price: Optional[float] = None,
+) -> dict:
+    result = (
+        _get_client()
+        .table("watch_price_history")
+        .insert(
+            {
+                "watch_id": watch_id,
+                "swisstimehouse_price": swisstimehouse_price,
+                "myntra_price": myntra_price,
+            }
+        )
+        .execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watch_price_history' returned no data: {result}")
+    return result.data[0]
+
+
+def get_last_watch_notified_price(watch_id: str) -> Optional[float]:
+    result = (
+        _get_client()
+        .table("watch_notifications_log")
+        .select("price")
+        .eq("watch_id", watch_id)
+        .order("notified_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if not result.data:
+        return None
+    return float(result.data[0]["price"])
+
+
+def log_watch_notification(watch_id: str, price: float, seller: str) -> dict:
+    logger.info("Logging watch notification: watch_id=%s price=%.2f seller=%s", watch_id, price, seller)
+    result = (
+        _get_client()
+        .table("watch_notifications_log")
+        .insert({"watch_id": watch_id, "price": price, "seller": seller})
+        .execute()
+    )
+    if not result.data:
+        raise RuntimeError(f"Insert into 'watch_notifications_log' returned no data: {result}")
+    return result.data[0]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_db.py -k watch -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `ruff check db/client.py tests/test_db.py`
+Expected: no errors.
+
+```bash
+git add db/client.py tests/test_db.py
+git commit -m "feat: add watch CRUD and price-history db helpers"
+```
+
+---
+
+## Task 6: Bot tools — add/list/get/set/remove watch
+
+**Files:**
+- Modify: `bot/functions.py`
+- Test: `tests/test_bot_functions.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_bot_functions.py`:
+
+```python
+def test_add_watch_asks_for_target_when_missing(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch(
+        "bot.functions.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0},
+    )
+    mock_db = mocker.patch("bot.functions.db_add_watch")
+    result = add_watch("https://www.swisstimehouse.com/casio-g1714")
+    assert "34997" in result
+    assert "target" in result.lower()
+    mock_db.assert_not_called()
+
+
+def test_add_watch_stores_with_target(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch(
+        "bot.functions.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0},
+    )
+    mock_db = mocker.patch("bot.functions.db_add_watch", return_value={"id": "w1", "name": "Casio G1714"})
+    result = add_watch("https://www.swisstimehouse.com/casio-g1714", target_price=30000.0)
+    assert "Casio G1714" in result
+    assert "30000" in result
+    mock_db.assert_called_once_with(
+        name="Casio G1714", brand="Casio", reference_no="G1714",
+        target_price=30000.0, swisstimehouse_url="https://www.swisstimehouse.com/casio-g1714",
+    )
+
+
+def test_add_watch_fetch_failure(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch("bot.functions.fetch_swisstimehouse", return_value=None)
+    result = add_watch("https://www.swisstimehouse.com/bad", target_price=30000.0)
+    assert "couldn't" in result.lower() or "could not" in result.lower() or "unable" in result.lower()
+
+
+def test_list_watches_with_rows(mocker):
+    from bot.functions import list_watches
+
+    mocker.patch(
+        "bot.functions.db_get_watches",
+        return_value=[{"name": "Casio G1714", "target_price": 30000.0}],
+    )
+    result = list_watches()
+    assert "Casio G1714" in result
+    assert "30000" in result
+
+
+def test_list_watches_empty(mocker):
+    from bot.functions import list_watches
+
+    mocker.patch("bot.functions.db_get_watches", return_value=[])
+    result = list_watches()
+    assert "empty" in result.lower() or "no watches" in result.lower()
+
+
+def test_set_watch_target_success(mocker):
+    from bot.functions import set_watch_target
+
+    mocker.patch("bot.functions.db_set_watch_target", return_value=True)
+    result = set_watch_target("Casio G1714", 25000.0)
+    assert "25000" in result
+
+
+def test_remove_watch_success(mocker):
+    from bot.functions import remove_watch
+
+    mocker.patch("bot.functions.db_remove_watch", return_value=True)
+    result = remove_watch("Casio G1714")
+    assert "no longer" in result.lower() or "removed" in result.lower()
+
+
+def test_dispatch_routes_to_add_watch(mocker):
+    from bot.functions import dispatch
+
+    mocker.patch(
+        "bot.functions.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0},
+    )
+    mocker.patch("bot.functions.db_add_watch", return_value={"id": "w1", "name": "Casio G1714"})
+    result = dispatch("add_watch", {"url": "https://www.swisstimehouse.com/casio-g1714", "target_price": 30000.0})
+    assert "Casio G1714" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_bot_functions.py -k watch -v`
+Expected: FAIL — `ImportError: cannot import name 'add_watch'`.
+
+- [ ] **Step 3: Implement the watch tools in `bot/functions.py`**
+
+Add to the imports block at the top of `bot/functions.py` (extend the existing `from db.client import (...)` and `from utils...` lines):
+
+```python
+from db.client import (
+    add_watch as db_add_watch,
+    get_watches as db_get_watches,
+    remove_watch as db_remove_watch,
+    set_watch_target as db_set_watch_target,
+)
+from utils.watches import fetch_swisstimehouse
+```
+
+Add these functions (anywhere among the other tool functions, before `TOOLS`):
+
+```python
+def add_watch(url: str, target_price: float = None) -> str:
+    logger.info("add_watch called: url=%s, target_price=%s", url, target_price)
+    watch = fetch_swisstimehouse(url)
+    if watch is None:
+        return (
+            f"Sorry, I couldn't read a price from that link. "
+            f"Make sure it's a swisstimehouse.com product page."
+        )
+    if target_price is None:
+        return (
+            f"**{watch['name']}** is currently ₹{watch['price']:.2f} on Swiss Time House. "
+            f"What target price (in ₹) should I alert you below?"
+        )
+    db_add_watch(
+        name=watch["name"],
+        brand=watch["brand"],
+        reference_no=watch["reference"],
+        target_price=target_price,
+        swisstimehouse_url=url,
+    )
+    return (
+        f"Tracking **{watch['name']}** (currently ₹{watch['price']:.2f}). "
+        f"I'll alert you when it drops below ₹{target_price:.2f}."
+    )
+
+
+def list_watches() -> str:
+    logger.info("list_watches called")
+    watches = db_get_watches()
+    if not watches:
+        return "Your watch list is empty. Add one with a swisstimehouse.com product link."
+    lines = ["**Watches you're tracking:**"]
+    for w in watches:
+        line = f"• {w['name']}"
+        if w.get("target_price") is not None:
+            line += f" (target: ₹{float(w['target_price']):.2f})"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def get_watch_price(name: str) -> str:
+    logger.info("get_watch_price called: name=%s", name)
+    watches = db_get_watches()
+    from db.client import _normalize
+    norm = _normalize(name)
+    match = next(
+        (w for w in watches if norm in _normalize(w["name"]) or _normalize(w["name"]) in norm),
+        None,
+    )
+    if not match or not match.get("swisstimehouse_url"):
+        return f"**{name}** isn't on your watch list."
+    fetched = fetch_swisstimehouse(match["swisstimehouse_url"])
+    if fetched is None:
+        return f"I couldn't fetch the current price for **{match['name']}** right now."
+    return f"**{match['name']}** is currently ₹{fetched['price']:.2f} on Swiss Time House."
+
+
+def set_watch_target(name: str, target_price: float) -> str:
+    logger.info("set_watch_target called: name=%s, target_price=%s", name, target_price)
+    updated = db_set_watch_target(name, target_price)
+    if not updated:
+        return f"**{name}** wasn't found in your watch list."
+    return f"Target price for **{name}** set to ₹{target_price:.2f}."
+
+
+def remove_watch(name: str) -> str:
+    logger.info("remove_watch called: name=%s", name)
+    removed = db_remove_watch(name)
+    if removed:
+        return f"No longer tracking **{name}**."
+    return f"**{name}** wasn't in your watch list."
+```
+
+Add these tool definitions to the `TOOLS` list (append inside the list):
+
+```python
+    {
+        "type": "function",
+        "function": {
+            "name": "add_watch",
+            "description": (
+                "Track a watch's price from a swisstimehouse.com product URL. "
+                "Provide a target price in INR; the user is alerted when the price drops below it. "
+                "If no target price is given, this returns the current price and asks for one."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string", "description": "A swisstimehouse.com product page URL."},
+                    "target_price": {
+                        "type": "number",
+                        "description": "Target price in INR. Alert fires when price drops to/below this.",
+                    },
+                },
+                "required": ["url"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_watches",
+            "description": "List all watches currently being tracked.",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_watch_price",
+            "description": "Get the current price of a tracked watch from swisstimehouse.com.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the tracked watch."}
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_watch_target",
+            "description": "Set or update the target price (INR) for a tracked watch.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the tracked watch."},
+                    "target_price": {"type": "number", "description": "New target price in INR."},
+                },
+                "required": ["name", "target_price"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "remove_watch",
+            "description": "Remove a watch from the watch list.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "The name of the watch to remove."}
+                },
+                "required": ["name"],
+            },
+        },
+    },
+```
+
+Add these entries to `_FUNCTION_MAP`:
+
+```python
+    "add_watch": add_watch,
+    "list_watches": list_watches,
+    "get_watch_price": get_watch_price,
+    "set_watch_target": set_watch_target,
+    "remove_watch": remove_watch,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_bot_functions.py -k watch -v`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `ruff check bot/functions.py tests/test_bot_functions.py`
+Expected: no errors.
+
+```bash
+git add bot/functions.py tests/test_bot_functions.py
+git commit -m "feat: add watch tools (add/list/get/set/remove) to bot"
+```
+
+---
+
+## Task 7: Discord watch alert
+
+**Files:**
+- Modify: `utils/discord.py`
+- Test: `tests/test_discord_webhook.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_discord_webhook.py`:
+
+```python
+def test_send_watch_alert_posts_message(mocker, monkeypatch):
+    from utils import discord
+
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.test/webhook")
+    mock_post = mocker.patch("utils.discord.requests.post")
+    mock_post.return_value.raise_for_status.return_value = None
+
+    discord.send_watch_alert(
+        watch_name="Casio G1714",
+        price=29000.0,
+        seller="Swiss Time House",
+        target_price=30000.0,
+        ai_commentary="Great time to buy.",
+    )
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    body = kwargs["json"]["content"]
+    assert "Casio G1714" in body
+    assert "29000" in body
+    assert "Swiss Time House" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_discord_webhook.py::test_send_watch_alert_posts_message -v`
+Expected: FAIL — `AttributeError: module 'utils.discord' has no attribute 'send_watch_alert'`.
+
+- [ ] **Step 3: Implement `send_watch_alert` in `utils/discord.py`**
+
+Append to `utils/discord.py`:
+
+```python
+def send_watch_alert(
+    watch_name: str,
+    price: float,
+    seller: str,
+    target_price: float,
+    ai_commentary: str,
+) -> None:
+    load_dotenv()
+    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL")
+    if not webhook_url:
+        raise EnvironmentError("DISCORD_WEBHOOK_URL is not set. Add it to your .env file.")
+    message = (
+        f"**Watch Deal Alert: {watch_name}**\n"
+        f"₹{price:.2f} on {seller} (target was ₹{target_price:.2f})\n"
+        f"{ai_commentary}"
+    )
+    response = requests.post(webhook_url, json={"content": message})
+    response.raise_for_status()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_discord_webhook.py::test_send_watch_alert_posts_message -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `ruff check utils/discord.py tests/test_discord_webhook.py`
+Expected: no errors.
+
+```bash
+git add utils/discord.py tests/test_discord_webhook.py
+git commit -m "feat: add send_watch_alert discord helper"
+```
+
+---
+
+## Task 8: Cron — `process_watch` and watch sweep
+
+**Files:**
+- Modify: `cron/price_check.py`
+- Test: `tests/test_cron.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cron.py`:
+
+```python
+@pytest.fixture
+def sample_watch():
+    return {
+        "id": "watch-uuid-1",
+        "name": "Casio G1714",
+        "target_price": 30000.0,
+        "swisstimehouse_url": "https://www.swisstimehouse.com/casio-g1714",
+        "myntra_url": None,
+    }
+
+
+def test_process_watch_sends_alert_below_target(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 29000.0},
+    )
+    mock_hist = mocker.patch("cron.price_check.insert_watch_price_history")
+    mocker.patch("cron.price_check.get_last_watch_notified_price", return_value=None)
+    mock_provider = MagicMock()
+    mock_provider.generate_text.return_value = "Buy now!"
+    mocker.patch("cron.price_check.get_provider", return_value=mock_provider)
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+    mock_log = mocker.patch("cron.price_check.log_watch_notification")
+
+    process_watch(sample_watch)
+
+    mock_hist.assert_called_once_with(
+        watch_id="watch-uuid-1", swisstimehouse_price=29000.0, myntra_price=None
+    )
+    mock_alert.assert_called_once()
+    _, kwargs = mock_alert.call_args
+    assert kwargs["watch_name"] == "Casio G1714"
+    assert kwargs["price"] == 29000.0
+    assert kwargs["seller"] == "Swiss Time House"
+    mock_log.assert_called_once_with("watch-uuid-1", 29000.0, "Swiss Time House")
+
+
+def test_process_watch_skips_above_target(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0},
+    )
+    mocker.patch("cron.price_check.insert_watch_price_history")
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_alert.assert_not_called()
+
+
+def test_process_watch_skips_when_not_lower_than_last_notified(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 29000.0},
+    )
+    mocker.patch("cron.price_check.insert_watch_price_history")
+    mocker.patch("cron.price_check.get_last_watch_notified_price", return_value=29000.0)
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_alert.assert_not_called()
+
+
+def test_process_watch_skips_when_no_price(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch("cron.price_check.fetch_swisstimehouse", return_value=None)
+    mock_hist = mocker.patch("cron.price_check.insert_watch_price_history")
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_hist.assert_called_once_with(
+        watch_id="watch-uuid-1", swisstimehouse_price=None, myntra_price=None
+    )
+    mock_alert.assert_not_called()
+
+
+def test_run_checks_watches_too(mocker):
+    from cron.price_check import run
+
+    mocker.patch("cron.price_check.get_games", return_value=[])
+    mocker.patch(
+        "cron.price_check.get_watches",
+        return_value=[{"id": "w1", "name": "Casio G1714"}],
+    )
+    mock_process_watch = mocker.patch("cron.price_check.process_watch")
+
+    run()
+    mock_process_watch.assert_called_once_with({"id": "w1", "name": "Casio G1714"})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cron.py -k watch -v`
+Expected: FAIL — `ImportError: cannot import name 'process_watch'`.
+
+- [ ] **Step 3: Implement `process_watch` and extend `run()`**
+
+In `cron/price_check.py`, extend the imports:
+
+```python
+from db.client import (
+    get_games,
+    get_last_notified_price,
+    get_last_watch_notified_price,
+    get_watches,
+    insert_price_history,
+    insert_watch_price_history,
+    log_notification,
+    log_watch_notification,
+)
+from utils.discord import send_deal_alert, send_watch_alert
+from utils.itad import get_best_price, get_historical_low
+from utils.watches import fetch_swisstimehouse
+```
+
+(Adjust the existing `from db.client import (...)` and `from utils.discord import ...` lines to the above — keep `get_provider` import as-is.)
+
+Add the `process_watch` function:
+
+```python
+_SWISS_SELLER = "Swiss Time House"
+
+
+def process_watch(watch: dict) -> None:
+    name = watch["name"]
+    logger.info("[%s] Fetching watch price...", name)
+
+    swiss_price = None
+    url = watch.get("swisstimehouse_url")
+    if url:
+        fetched = fetch_swisstimehouse(url)
+        if fetched is not None:
+            swiss_price = fetched["price"]
+
+    insert_watch_price_history(
+        watch_id=watch["id"], swisstimehouse_price=swiss_price, myntra_price=None
+    )
+
+    # Lowest available price across sources (only swisstimehouse in v1).
+    candidates = [(swiss_price, _SWISS_SELLER)]
+    available = [(p, s) for p, s in candidates if p is not None]
+    if not available:
+        logger.info("[%s] No price available this sweep, skipping.", name)
+        return
+
+    price, seller = min(available, key=lambda ps: ps[0])
+    target = float(watch["target_price"])
+    if price > target:
+        logger.info("[%s] ₹%.2f above target ₹%.2f, skipping.", name, price, target)
+        return
+
+    last_notified = get_last_watch_notified_price(watch["id"])
+    if last_notified is not None and price >= last_notified:
+        logger.info(
+            "[%s] ₹%.2f not lower than last notified ₹%.2f, skipping.",
+            name, price, last_notified,
+        )
+        return
+
+    logger.info("[%s] Deal! ₹%.2f on %s. Generating commentary...", name, price, seller)
+    provider = get_provider()
+    commentary = provider.generate_text(
+        f"Write a one-sentence buy recommendation for the watch '{name}'. "
+        f"Current price: ₹{price} on {seller}, below the user's target of ₹{target}."
+    )
+    send_watch_alert(
+        watch_name=name,
+        price=price,
+        seller=seller,
+        target_price=target,
+        ai_commentary=commentary,
+    )
+    log_watch_notification(watch["id"], price, seller)
+    logger.info("[%s] Watch alert sent!", name)
+```
+
+Extend `run()` — after the existing game loop and before the final log line, add:
+
+```python
+    watches = get_watches()
+    logger.info("Checking prices for %d watch(es)...", len(watches))
+    for watch in watches:
+        try:
+            process_watch(watch)
+        except Exception as exc:
+            logger.error("[%s] ERROR: %s", watch["name"], exc, exc_info=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cron.py -k watch -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Run the full cron test file to confirm no regressions**
+
+Run: `pytest tests/test_cron.py -v`
+Expected: all PASS (existing game tests + new watch tests).
+
+- [ ] **Step 6: Lint and commit**
+
+Run: `ruff check cron/price_check.py tests/test_cron.py`
+Expected: no errors.
+
+```bash
+git add cron/price_check.py tests/test_cron.py
+git commit -m "feat: add process_watch and watch sweep to cron"
+```
+
+---
+
+## Task 9: Extend the agent system prompt
+
+**Files:**
+- Modify: `ai/graph.py:26-32`
+
+- [ ] **Step 1: Update `_SYSTEM_PROMPT`**
+
+Replace the existing `_SYSTEM_PROMPT` assignment in `ai/graph.py` with:
+
+```python
+_SYSTEM_PROMPT = (
+    "You are DropHunter, a personal deal assistant for games and watches. "
+    "For games: when the user asks to track, untrack, list games, check prices, see recent deals, "
+    "check historical lows, or set target prices, use the available tools. "
+    "For watches: the user tracks a watch by giving a swisstimehouse.com product URL. "
+    "Use add_watch with the URL; a target price in INR is required, so if the user hasn't given one, "
+    "add_watch will report the current price and you should ask them for a target. "
+    "Use list_watches, get_watch_price, set_watch_target, and remove_watch for watch management. "
+    "You can call multiple tools in sequence if needed. "
+    "For anything else, respond helpfully in plain text."
+)
+```
+
+- [ ] **Step 2: Run the graph tests to confirm nothing broke**
+
+Run: `pytest tests/test_graph.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3: Lint and commit**
+
+Run: `ruff check ai/graph.py`
+Expected: no errors.
+
+```bash
+git add ai/graph.py
+git commit -m "feat: teach agent about watch tracking"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pytest -v`
+Expected: all tests PASS (existing + new). If any existing test fails, fix the regression before proceeding.
+
+- [ ] **Step 2: Lint the whole project**
+
+Run: `ruff check .`
+Expected: no errors.
+
+- [ ] **Step 3: Manual smoke test of the live fetch (optional but recommended)**
+
+Run:
+
+```bash
+python -c "from utils.watches import fetch_swisstimehouse; print(fetch_swisstimehouse('https://www.swisstimehouse.com/casio-g1714'))"
+```
+
+Expected: a dict like `{'name': 'Casio G1714 - ...', 'brand': 'Casio', 'reference': 'G1714', 'price': 34997.0}` (price may differ if it changed). If it prints `None`, Cloudflare may have escalated its challenge — note this; the cron path already degrades gracefully (records `None`, sends no false alert).
+
+- [ ] **Step 4: Final commit (if any lint fixes were made)**
+
+```bash
+git add -A
+git commit -m "chore: watch tracking final verification fixes"
+```
+
+---
+
+## Self-Review Notes (spec coverage)
+
+- swisstimehouse fetch + JSON-LD parse → Task 3 ✓
+- 3 watch tables (myntra columns reserved, NULL in v1) → Task 4 ✓
+- DB helpers (CRUD, history, notifications, dedup) → Task 5 ✓
+- Tools (add/list/get/set/remove) + required target + "ask for target" flow + upsert → Task 6 ✓
+- Discord watch alert → Task 7 ✓
+- `process_watch` with lowest-available-price + target + dedup + graceful None → Task 8 ✓
+- Agent system prompt → Task 9 ✓
+- `cloudscraper` + `beautifulsoup4` deps → Task 1 ✓
+- Myntra deferred (schema present, no scraper) → reflected throughout ✓

--- a/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
+++ b/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
@@ -1,0 +1,164 @@
+# Watch Tracking — Design Spec
+
+**Date:** 2026-05-30
+**Status:** Approved, ready for implementation plan
+**Scope:** v1 — track watches from swisstimehouse.com by URL, with a schema ready for additional sources (Myntra, official brand sites) that are not yet built.
+
+## Background
+
+DropHunter currently tracks **game** prices via the IsThereAnyDeal (ITAD) API. ITAD does the heavy lifting: one API call returns prices across ~10 stores plus an all-time historical low, keyed off a canonical product ID. The `games` table, the cron sweep, and the LLM tools all assume this aggregator exists.
+
+There is **no ITAD-equivalent for watches.** This feature adds a parallel path for tracking watch prices from authentic sellers, starting with a single source.
+
+## Goals
+
+- Let a user track a watch by pasting its **swisstimehouse.com product URL** and setting a **required target price**.
+- The background cron sweep re-fetches the page, records the price over time, and fires a Discord alert when the price drops to or below the target.
+- The data model is designed for **multiple price sources** (swisstimehouse, Myntra, brand sites) so future sources slot in without a schema migration — but only swisstimehouse is implemented in v1.
+
+## Non-Goals (v1)
+
+- Myntra scraping (schema is ready; the scraper is **not** built — see Deferred Work).
+- Official brand-site comparison (e.g. casio.in).
+- Cross-site automatic product matching — the user asserts "same watch" by pasting each site's specific product URL.
+- A historical-low data source for watches — there is none; we accumulate our own history over time, which is why **target price is required** (unlike games, where it is optional).
+
+## Key Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Price source | Direct page fetch of the pasted URL | No reliable watch aggregator; one known site is cheap and reliable to parse |
+| Code structure | Separate `watches` path parallel to the game path | Zero risk to the working game flow |
+| Seller trust | Curated authentic sellers; v1 = swisstimehouse only | User wants authentic sellers, not marketplaces/gray-market |
+| Multi-source storage | **Wide columns** (`swisstimehouse_price`, `myntra_price`) | Matches the mental model; lowest available price wins |
+| Unavailable source | Stored as `NULL` | A blocked/absent source must not break the alert; lowest *available* price drives it |
+| Price extraction | Deterministic HTML parse (BeautifulSoup), not LLM | Runs every sweep; must be free/fast; isolated and logs loudly on layout change |
+| Target price | **Required** for watches | No historical-low fallback exists |
+
+## Architecture
+
+A parallel watch path that reuses the existing notification/dedup/Discord infrastructure but swaps the price source:
+
+```
+User pastes swisstimehouse URL + target  ──▶ add_watch tool
+                                               │ fetch_swisstimehouse(url)
+                                               ▼
+                                          watches table (target_price required)
+
+cron run()  ──▶ process_watch(watch) for each watch
+                  │ fetch_swisstimehouse(url)  (myntra deferred → NULL)
+                  ▼
+              watch_price_history snapshot (per-source prices, NULL = unavailable)
+                  │ lowest available price ≤ target_price AND < last notified?
+                  ▼
+              Discord alert (names winning seller, AI commentary) + watch_notifications_log
+```
+
+## Data Model
+
+Three new tables. The `games`, `price_history`, and `notifications_log` tables are **untouched**.
+
+```sql
+create table if not exists watches (
+    id uuid primary key default gen_random_uuid(),
+    name text not null,                         -- "Casio G-Shock GM-B2100SD-1CDR"
+    brand text null,
+    reference_no text null,                     -- model/ref, e.g. "GM-B2100SD-1CDR"
+    target_price numeric not null,              -- REQUIRED (no historical-low fallback)
+    swisstimehouse_url text null,
+    myntra_url text null,                       -- reserved for v2; always NULL in v1
+    added_at timestamptz not null default now()
+    -- app-enforced: at least one source URL must be present
+);
+
+create table if not exists watch_price_history (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    swisstimehouse_price numeric null,          -- NULL = absent/blocked
+    myntra_price numeric null,                  -- NULL until v2
+    fetched_at timestamptz not null default now()
+);
+
+create table if not exists watch_notifications_log (
+    id uuid primary key default gen_random_uuid(),
+    watch_id uuid not null references watches(id) on delete cascade,
+    price numeric not null,
+    seller text not null,                       -- which source won the alert
+    notified_at timestamptz not null default now()
+);
+
+create index if not exists idx_watch_price_history_watch_id on watch_price_history(watch_id);
+create index if not exists idx_watch_notifications_log_watch_id on watch_notifications_log(watch_id);
+```
+
+**Alert condition:** the lowest non-NULL price across source columns, compared against `target_price`, deduped so we only re-alert when the new price is lower than the last notified price.
+
+## Components
+
+### `utils/watches.py` (new, parallel to `utils/itad.py`)
+
+- `fetch_swisstimehouse(url) -> dict | None`
+  - Validates the URL host is `swisstimehouse.com`.
+  - Fetches the page with `requests` (existing dep) and a normal browser User-Agent.
+  - Parses with BeautifulSoup (new dep) targeting the price element. The product page has **no JSON-LD / schema.org markup** — the price is plain HTML text (observed: regular `₹ 49,995`, reduced `₹ 34,997`, "Save 30%"). The parser extracts the reduced (current) price and the regular price, and the product title (for `name`/`brand`/`reference`).
+  - Returns `{name, brand, reference, price, regular_price}`, or `None` if the price element cannot be found — logging loudly at WARNING so a layout change is obvious.
+  - Isolated in one small function so a future site-HTML change is a one-spot fix.
+- `fetch_myntra(url)` — **deferred**, not implemented in v1 (documented stub at most). Myntra is JS-rendered and bot-protected; it will require spoofed headers, its internal product JSON, or a headless browser. When built, it returns a price or `None`.
+
+### `bot/functions.py` (new tools, registered in `TOOLS` + `_FUNCTION_MAP`)
+
+- `add_watch(swisstimehouse_url, target_price=None)`
+  - Validates and fetches the URL. If not found/parseable, returns a clear error.
+  - If `target_price` is omitted, the bot replies with the current price and **asks the user for a target** (it does not store yet).
+  - **Upserts** the watch (on `swisstimehouse_url`), so re-adding later with a different/added source fills it in without duplicating.
+  - On success, replies with the current price and the configured target.
+- `list_watches()` — lists tracked watches with their target prices and latest known price.
+- `get_watch_price(name)` — fuzzy-matches a tracked watch by name (reuse the `_normalize`/`_find` pattern from `db/client.py`) and returns its current price(s).
+- `set_watch_target(name, target_price)` — updates the target.
+- `remove_watch(name)` — removes a watch.
+- Graph system prompt (`ai/graph.py`) extended: DropHunter also tracks watches; watches are added by pasting a swisstimehouse.com URL and require a target price.
+
+### `db/client.py` (new helpers, parallel to game helpers)
+
+- `add_watch`, `get_watches`, `set_watch_target`, `remove_watch` (fuzzy match by name).
+- `insert_watch_price_history(watch_id, swisstimehouse_price, myntra_price)`.
+- `get_last_watch_notified_price(watch_id)`, `log_watch_notification(watch_id, price, seller)`.
+
+### `cron/price_check.py` (new `process_watch`, added to `run()`)
+
+`process_watch(watch)`:
+1. Fetch each configured source (v1: swisstimehouse only; myntra → `None`).
+2. Insert a `watch_price_history` snapshot with per-source prices.
+3. Compute the lowest **non-NULL** price and which seller it came from.
+4. If lowest ≤ `target_price` **and** lower than the last notified price → generate AI commentary (reuse `get_provider().generate_text`), send a Discord alert via a thin watch wrapper around `utils/discord.py`, and log the notification.
+5. Errors per watch are caught and logged without aborting the sweep (mirror the existing game loop).
+
+`run()` runs the existing game loop, then the watch loop.
+
+### `utils/discord.py`
+
+Add `send_watch_alert(...)` (thin wrapper / parallel to `send_deal_alert`) showing watch name, winning seller, current price, target, and AI commentary. Reuse the webhook plumbing.
+
+## Error Handling
+
+- swisstimehouse fetch failure or unparseable price → `None`, logged at WARNING; the watch is skipped that sweep (no false alert).
+- Invalid/non-swisstimehouse URL on `add_watch` → clear user-facing error, nothing stored.
+- DB errors in the watch loop are caught per-watch so one failure doesn't abort the sweep.
+
+## Testing
+
+Unit tests parallel to the existing suite:
+- `fetch_swisstimehouse` against a **saved HTML fixture** of a real product page (price + title extraction, and the `None` path when the price element is absent).
+- URL host validation (accept swisstimehouse.com, reject others).
+- Lowest-available-price selection with `None` handling (one source NULL, both NULL).
+- `process_watch` target + dedup logic with mocked fetch and DB (alerts at/below target, suppresses when not lower than last notified, skips when price unavailable).
+
+## New Dependency
+
+- `beautifulsoup4` (added to `requirements.txt` / `pyproject.toml`). `requests` is already present.
+
+## Deferred Work (v2+)
+
+- **Myntra** as a second source: implement `fetch_myntra`, populate `myntra_price`/`myntra_url`, accept the Myntra URL in `add_watch`. The wide-column schema and `least(available)` alert logic already accommodate it.
+- **Official brand sites** (e.g. casio.in keyed off brand) as further sources.
+- Generalizing `games` + `watches` into a single `products` abstraction if a third product type appears (YAGNI for now).

--- a/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
+++ b/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
@@ -32,7 +32,8 @@ There is **no ITAD-equivalent for watches.** This feature adds a parallel path f
 | Seller trust | Curated authentic sellers; v1 = swisstimehouse only | User wants authentic sellers, not marketplaces/gray-market |
 | Multi-source storage | **Wide columns** (`swisstimehouse_price`, `myntra_price`) | Matches the mental model; lowest available price wins |
 | Unavailable source | Stored as `NULL` | A blocked/absent source must not break the alert; lowest *available* price drives it |
-| Price extraction | Deterministic HTML parse (BeautifulSoup), not LLM | Runs every sweep; must be free/fast; isolated and logs loudly on layout change |
+| Fetch | `cloudscraper` (not plain `requests`) | swisstimehouse is behind Cloudflare; plain `requests` returns 403. `cloudscraper` passes the challenge (verified, HTTP 200) |
+| Price extraction | Parse embedded `schema.org` JSON-LD, not visible HTML or LLM | The page embeds a clean `Product` block (`name`, `sku`, `brand.name`, `offers.price`); far more stable than scraping price text. Runs every sweep, free and fast |
 | Target price | **Required** for watches | No historical-low fallback exists |
 
 ## Architecture
@@ -99,10 +100,11 @@ create index if not exists idx_watch_notifications_log_watch_id on watch_notific
 
 - `fetch_swisstimehouse(url) -> dict | None`
   - Validates the URL host is `swisstimehouse.com`.
-  - Fetches the page with `requests` (existing dep) and a normal browser User-Agent.
-  - Parses with BeautifulSoup (new dep) targeting the price element. The product page has **no JSON-LD / schema.org markup** — the price is plain HTML text (observed: regular `₹ 49,995`, reduced `₹ 34,997`, "Save 30%"). The parser extracts the reduced (current) price and the regular price, and the product title (for `name`/`brand`/`reference`).
-  - Returns `{name, brand, reference, price, regular_price}`, or `None` if the price element cannot be found — logging loudly at WARNING so a layout change is obvious.
-  - Isolated in one small function so a future site-HTML change is a one-spot fix.
+  - Fetches the page with `cloudscraper` (new dep) — plain `requests` is blocked by Cloudflare (403); `cloudscraper` passes the challenge (verified, HTTP 200).
+  - Parses the embedded `schema.org` JSON-LD: finds `<script type="application/ld+json">` blocks (via BeautifulSoup), `json.loads` each, and selects the object whose `@type == "Product"`. Reads `name`, `brand.name`, `sku` (→ `reference`), and `offers.price` (→ `price`; the field may be an int or a string, so coerce to `float`). Confirmed live values: `name="Casio G1714 - GM-B2100SD-1CDR G-Shock Watch"`, `brand="Casio"`, `sku="G1714"`, `offers.price=34997`, `offers.priceCurrency="INR"`.
+  - Returns `{name, brand, reference, price}`, or `None` if the request fails or no `Product` JSON-LD with a price is found — logging loudly at WARNING so a Cloudflare block or markup change is obvious.
+  - Isolated in one small function so a future site change is a one-spot fix.
+  - **Note:** `regular_price` is intentionally dropped — JSON-LD exposes only the current price, and target-based alerts don't need a list price.
 - `fetch_myntra(url)` — **deferred**, not implemented in v1 (documented stub at most). Myntra is JS-rendered and bot-protected; it will require spoofed headers, its internal product JSON, or a headless browser. When built, it returns a price or `None`.
 
 ### `bot/functions.py` (new tools, registered in `TOOLS` + `_FUNCTION_MAP`)
@@ -153,9 +155,12 @@ Unit tests parallel to the existing suite:
 - Lowest-available-price selection with `None` handling (one source NULL, both NULL).
 - `process_watch` target + dedup logic with mocked fetch and DB (alerts at/below target, suppresses when not lower than last notified, skips when price unavailable).
 
-## New Dependency
+## New Dependencies
 
-- `beautifulsoup4` (added to `requirements.txt` / `pyproject.toml`). `requests` is already present.
+- `cloudscraper` — passes swisstimehouse's Cloudflare challenge (plain `requests` 403s).
+- `beautifulsoup4` — locating the `<script type="application/ld+json">` blocks.
+
+Both added to `requirements.txt`. `requests` is already present (pulled in transitively too).
 
 ## Deferred Work (v2+)
 

--- a/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
+++ b/docs/superpowers/specs/2026-05-30-watch-tracking-design.md
@@ -114,7 +114,7 @@ create index if not exists idx_watch_notifications_log_watch_id on watch_notific
   - If `target_price` is omitted, the bot replies with the current price and **asks the user for a target** (it does not store yet).
   - **Upserts** the watch (on `swisstimehouse_url`), so re-adding later with a different/added source fills it in without duplicating.
   - On success, replies with the current price and the configured target.
-- `list_watches()` — lists tracked watches with their target prices and latest known price.
+- `list_watches()` — lists tracked watches with their target prices (no live price fetch on a list call).
 - `get_watch_price(name)` — fuzzy-matches a tracked watch by name (reuse the `_normalize`/`_find` pattern from `db/client.py`) and returns its current price(s).
 - `set_watch_target(name, target_price)` — updates the target.
 - `remove_watch(name)` — removes a watch.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ langgraph>=0.2.0
 langfuse>=3.0.0
 pytest==8.1.1
 pytest-mock==3.14.0
+cloudscraper==1.2.71
+beautifulsoup4==4.12.3

--- a/tests/fixtures/swisstimehouse_casio_g1714.html
+++ b/tests/fixtures/swisstimehouse_casio_g1714.html
@@ -1,0 +1,9551 @@
+<!doctype html>
+<html lang="en">
+<head>
+	
+		
+  <meta charset="utf-8">
+
+
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+
+
+  <title>Buy Casio Casio G1714 Watch in India I Swiss Time House</title>
+  
+    
+  
+  <meta name="description" content="Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu...">
+  <meta name="keywords" content="buy Casio Casio G1714 online, shop Casio watch, Casio G1714, shop G1714, shop Casio at lowest price, G-Shock Watches , Casio  Casio G1714">
+        <link rel="canonical" href="https://www.swisstimehouse.com/casio-g1714">
+    
+      
+
+  
+    
+  
+
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+  <link rel="icon" type="image/vnd.microsoft.icon" href="https://www.swisstimehouse.com/img/favicon.ico?1665736482">
+  <link rel="shortcut icon" type="image/x-icon" href="https://www.swisstimehouse.com/img/favicon.ico?1665736482">
+
+
+
+  <meta property="og:title" content="Buy Casio Casio G1714 Watch in India I Swiss Time House"/>
+  <meta property="og:description" content="Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu..."/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="https://www.swisstimehouse.com/casio-g1714"/>
+<meta property="og:site_name" content="Swiss Time House"/>
+
+  <meta property="og:type" content="product"/>
+            <meta property="og:image" content="https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg"/>
+          <meta property="og:image" content="https://www.swisstimehouse.com/196160-thickbox_default/casio-g1714.jpg"/>
+          <meta property="og:image" content="https://www.swisstimehouse.com/196161-thickbox_default/casio-g1714.jpg"/>
+          <meta property="og:image" content="https://www.swisstimehouse.com/196162-thickbox_default/casio-g1714.jpg"/>
+          <meta property="og:image" content="https://www.swisstimehouse.com/196163-thickbox_default/casio-g1714.jpg"/>
+        <meta property="og:image:height" content="1422"/>
+    <meta property="og:image:width" content="1100"/>
+
+        <meta property="product:price:amount" content="34997" />
+    <meta property="product:price:currency" content="INR" />
+          <meta property="product:price:standard_amount" content="49995" />
+            <meta property="product:brand" content="Casio" />
+    <meta property="og:availability" content="instock" />
+<meta name="twitter:card" content="summary_large_image">
+<meta property="twitter:title" content="Buy Casio Casio G1714 Watch in India I Swiss Time House"/>
+  <meta property="twitter:description" content="Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu..."/>
+<meta property="twitter:site" content="Swiss Time House"/>
+<meta property="twitter:creator" content="Swiss Time House"/>
+<meta property="twitter:domain" content="https://www.swisstimehouse.com/casio-g1714"/>
+
+  <meta property="twitter:image" content="https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg"/>
+      <meta property="twitter:image:alt" content="Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu..."/>
+  
+
+      <script type="application/ld+json">
+      {
+    "@context": "http://schema.org/",
+    "@type": "Product",
+    "name": "Casio G1714 - GM-B2100SD-1CDR G-Shock Watch",
+    "category": "G-Shock Watches",
+    "description": "Casio G1714 Men's Watch with 2 Year National Warranty ( 1St Year International Warranty )",
+    "image": "https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg",
+    "sku": "G1714",
+    "gtin13": "4549526401541",
+    "brand": {
+        "@type": "Brand",
+        "name": "Casio"
+    },
+    "offers": {
+        "@type": "Offer",
+        "name": "Casio G1714 - GM-B2100SD-1CDR G-Shock Watch",
+        "price": 34997,
+        "url": "https://www.swisstimehouse.com/casio-g1714",
+        "priceCurrency": "INR",
+        "image": [
+            "https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg",
+            "https://www.swisstimehouse.com/196160-thickbox_default/casio-g1714.jpg",
+            "https://www.swisstimehouse.com/196161-thickbox_default/casio-g1714.jpg",
+            "https://www.swisstimehouse.com/196162-thickbox_default/casio-g1714.jpg",
+            "https://www.swisstimehouse.com/196163-thickbox_default/casio-g1714.jpg"
+        ],
+        "sku": "G1714",
+        "availability": "http://schema.org/InStock",
+        "priceValidUntil": "2027-03-31"
+    }
+}
+    </script>
+        <script type="application/ld+json">
+      {
+    "@context": "http://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.swisstimehouse.com/"
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Products",
+            "item": "https://www.swisstimehouse.com/products"
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Watches",
+            "item": "https://www.swisstimehouse.com/watches"
+        },
+        {
+            "@type": "ListItem",
+            "position": 4,
+            "name": "Accessible & Desirable Brands",
+            "item": "https://www.swisstimehouse.com/accessible-desirable-brands"
+        },
+        {
+            "@type": "ListItem",
+            "position": 5,
+            "name": "Casio Watches",
+            "item": "https://www.swisstimehouse.com/casio-watches"
+        },
+        {
+            "@type": "ListItem",
+            "position": 6,
+            "name": "G-Shock Watches",
+            "item": "https://www.swisstimehouse.com/g-shock-watches"
+        },
+        {
+            "@type": "ListItem",
+            "position": 7,
+            "name": "Casio G1714 - GM-B2100SD-1CDR G-Shock Watch",
+            "item": "https://www.swisstimehouse.com/casio-g1714"
+        }
+    ]
+}
+    </script>
+        <script type="application/ld+json">
+      {
+    "@context": "http://schema.org",
+    "@type": "Organization",
+    "name": "Swiss Time House",
+    "url": "https://www.swisstimehouse.com/",
+    "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.swisstimehouse.com/img/swiss-time-house-logo-1665736482.jpg"
+    },
+    "contactPoint": {
+        "@type": "ContactPoint",
+        "telephone": "+919142012345",
+        "contactType": "customer service"
+    },
+    "address": {
+        "@type": "PostalAddress",
+        "postalCode": "682031",
+        "streetAddress": "GCDA Complex",
+        "addressLocality": "Cochin, India"
+    }
+}
+    </script>
+  
+<!-- Facebook Pixel Code -->
+
+<script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.agent='plprestashop-download'; // n.agent to keep because of partnership
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js');
+
+    // Allow third-party modules to disable Pixel
+    fbq('consent', !!window.doNotConsentToPixel ? 'revoke' : 'grant');
+
+            fbq('init', '712870239433692', {"ct":null,"country":null,"zp":null,"ph":null,"gender":null,"fn":null,"ln":null,"em":null,"bd":null,"st":null});
+        
+    fbq('track', 'PageView');
+</script>
+
+<noscript>
+    <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=712870239433692&ev=PageView&noscript=1"/>
+</noscript>
+
+<!-- End Facebook Pixel Code -->
+
+<!-- Set Facebook Pixel Product Export -->
+        <meta property="og:type" content="product">
+      <meta property="og:url" content="https://www.swisstimehouse.com/casio-g1714">
+      <meta property="og:title" content="Buy Casio Casio G1714 Watch in India I Swiss Time House">
+      <meta property="og:site_name" content="Swiss Time House">
+      <meta property="og:description" content="Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu...">
+      <meta property="og:image" content="https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg">
+                <meta property="product:pretax_price:amount" content="34997">
+          <meta property="product:pretax_price:currency" content="INR">
+          <meta property="product:price:amount" content="34997">
+          <meta property="product:price:currency" content="INR">
+                          <meta property="product:brand" content="Casio">
+            <meta property="product:availability" content="in stock">
+      <meta property="product:condition" content="new">
+      <meta property="product:retailer_item_id" content="125701-0">
+      <meta property="product:item_group_id" content="125701">
+      <meta property="product:category" content="201"/>
+  <!-- END OF Set Facebook Pixel Product Export -->
+    
+        <script>
+            fbq(
+                'track',
+                'ViewContent',
+                {"currency":"inr","content_ids":["125701-0"],"contents":[{"id":"125701-0","title":"Casio G1714 - GM-B2100SD-1CDR G-Shock Watch","category":"Home > Products > Watches > Accessible & Desirable Brands > Casio Watches > G-Shock Watches","item_price":34997,"brand":"Casio"}],"content_type":"product","value":34997},
+                {"eventID":"ViewContent_1780145621_6a1addd53102b6.57776741"}
+            );
+        </script>
+    
+<!-- Open Graph -->
+<meta property="fb:admins" content="mohamed vasif,hafiz salahudin,abdul karim" /><meta property="og:title" content="Casio | Shop Casio Casio G1714 - GM-B2100SD-1CDR G-Shock Watch .Fre..." />
+<meta property="og:description" content="Buy Casio watches for Men and Women at lowest prices. Authorized Retailer for Casio watches in India- swisstimehouse.com" />
+<meta property="og:image" content="https://www.swisstimehouse.com/196159-1/casio-g1714.jpg" /><meta property="og:type" content="product" />
+
+<!-- Twitter Cards -->
+<meta name="twitter:domain" content="www.swisstimehouse.com" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+<meta http-equiv="cleartype" content="on" />
+<meta http-equiv="x-dns-prefetch-control" value="on" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="MobileOptimized" content="640" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<link rel="dns-prefetch" href="//www.google-analytics.com" />
+<link rel="dns-prefetch" href="//twitter.com" />
+<link rel="dns-prefetch" href="//facebook.com" />
+<link rel="dns-prefetch" href="//apis.google.com" />
+<link rel="dns-prefetch" href="//fonts.googleapis.com" />
+<link rel="dns-prefetch" href="//ssl.gstatic.com" />
+<link rel="dns-prefetch" href="//www.swisstimehouse.com" />
+
+<link rel="preconnect" href="//www.google-analytics.com" crossorigin />
+<link rel="preconnect" href="//twitter.com" crossorigin />
+<link rel="preconnect" href="//facebook.com" crossorigin />
+<link rel="preconnect" href="//apis.google.com" crossorigin />
+<link rel="preconnect" href="//fonts.googleapis.com" crossorigin />
+<link rel="preconnect" href="//ssl.gstatic.com" crossorigin />
+<link rel="preconnect" href="//www.swisstimehouse.com" crossorigin />
+
+
+
+
+
+
+<script type="text/javascript">
+    var is_mobile_spmgsnipreview = '1';
+    var spmgsnipreview_is_rewrite = '1';
+</script>
+
+
+
+
+
+    <script type="text/javascript">
+
+                    var baseDir = 'https://www.swisstimehouse.com/';
+        
+
+
+        var ajax_productreviews_url_spmgsnipreview = 'https://www.swisstimehouse.com/module/spmgsnipreview/ajaxreviews?token=21bb8423bb5d1270727450c8de563c7e0fee40e3';
+
+    </script>
+
+
+
+
+
+
+<style type="text/css">
+.page-item.active .page-link, .page-item.active .page-link:focus, .page-item.active .page-link:hover
+{
+    background-color:#F7B900;
+    border-color:#F7B900;
+}
+a.page-link:hover {
+    background-color:#F7B900!important  ;
+    color:#fff;
+    border-color:#F7B900;
+}
+
+    </style>
+
+
+
+                        
+
+
+
+
+
+
+
+
+
+
+    <script type="text/javascript">
+
+        var ajax_users_url_spmgsnipreview = 'https://www.swisstimehouse.com/module/spmgsnipreview/ajaxusers?token=21bb8423bb5d1270727450c8de563c7e0fee40e3';
+
+        
+        
+    </script>
+
+
+
+
+
+
+
+
+
+    
+
+
+    <style type="text/css">
+
+
+        .interactive-top-right-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+        .interactive-top-left-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+
+        .interactive-bottom-right-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+        .interactive-bottom-left-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+
+        #interactive-bar-right-s-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+
+        #interactive-bar-left-s-spmgsnipreview{
+            background-color: #c45500;
+        }
+
+
+        .interactive-field-custom-spmgsnipreview{
+            background-color:#fafafa;
+        }
+
+
+    </style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script type="text/javascript">
+
+    var ajax_storereviews_url_spmgsnipreview = 'https://www.swisstimehouse.com/module/spmgsnipreview/ajaxshopreviews?token=21bb8423bb5d1270727450c8de563c7e0fee40e3';
+
+
+    
+
+
+</script>
+
+
+
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD_PuoIlhGD1qX38nJtWpz6_wvjETtthP4&region=IN"></script>
+<script type="text/javascript">
+    // <![CDATA[
+    var map;
+		var current_productId=125701;
+	    var infoWindow;
+    var markers = [];
+    var maxDate = "2026-06-30";
+    var calYear = parseInt("2026");
+    var prevNav = '<i class="material-icons">keyboard_arrow_left</i>';
+    var nextNav = '<i class="material-icons">keyboard_arrow_right</i>';
+    var locationSelect = document.getElementById('locationSelect');
+    var defaultLat = '17.4123487';
+    var defaultLong = '78.4080455';
+    var default_store = '17';
+    var sl_carrier = '125';
+    var defaultZoom = 4;
+    var hasStoreIcon = '1';
+    var distance_unit = 'km';
+    var img_store_dir = '/img/st/';
+    var img_ps_dir = 'https://www.swisstimehouse.com/img/';
+    var searchUrl = 'https://www.swisstimehouse.com/storefinder';
+    var logo_store = 'logo_stores.png';
+        var autolocateUser = 0;
+	//var autolocateUser = 1;
+    var CurrentUrl = 'www.swisstimehouse.com/casio-g1714';
+    CurrentUrl = location.search.split('goforstore=')[1];
+    var search_link = "https://www.swisstimehouse.com/search";
+    var FMESL_STORE_EMAIL = parseInt("1");
+    var FMESL_STORE_FAX = parseInt("0");
+    var FMESL_STORE_NOTE = parseInt("0");
+    var FMESL_STORE_GLOBAL_ICON = parseInt("0");
+    var FMESL_LAYOUT_THEME = parseInt("1");
+    var FMESL_MAP_LINK = parseInt("1");
+    var FMESL_PICKUP_STORE = parseInt("1");
+    var FMESL_PICKUP_DATE = parseInt("0");
+    var st_page = "product";
+    var locale = "en";
+    var preselectedPickupTime = "";
+    var preselectedPickupDate = "";
+
+    // multilingual labels
+    var translation_1 = 'No stores were found. Please try selecting a wider radius.';
+    var translation_2 = 'store found -- see details:';
+    var translation_3 = 'stores found -- view all results:';
+    var translation_4 = 'Phone:';
+    var translation_5 = 'Get directions';
+    var translation_6 = 'Not found';
+    var translation_7 = 'Email:';
+    var translation_8 = 'Fax:';
+    var translation_9 = 'Note:';
+    var translation_10 = 'Distance:';
+    var translation_11 = 'View';
+    var translation_01 = 'Unable to find your location';
+    var translation_02 = 'Permission denied';
+    var translation_03 = 'Your location unknown';
+    var translation_04 = 'Timeout error';
+    var translation_05 = 'Location detection not supported in browser';
+    var translation_06 = 'Your current Location';
+    var translation_07 = 'You are near this location';
+    var translation_store_sel = 'Select Store';
+    var available_date_label = 'Available Dates';
+    var disabled_date_label = 'Unavailable Dates';
+    var invalid_pickupdate_label = 'Please enter a valid date.';
+    var invalid_pickuptime_label = 'Please enter a valid time.';
+    var store_page_error_label = 'Please select a pickup store.';
+    //]]>
+</script>
+<!--Module: ybc_instagram -->
+<script type="text/javascript">
+    var ybcInsTransNext = "Next";
+    var ybcInsTransBack = "Back";
+    var ybcInsTransLikes = "Likes";
+    var ybcInsTransClickVideo = "Click here to open this video on Instagram";
+    var ybcInsTransClickImage = "Click here to open this image on Instagram";
+    var ybcInsTransInstagram = "Instagram";
+    var ybcInsTransMorePhoto = "More photo";
+        var YBC_INS_ENABLE_SIDEBAR = 1;
+        var YBC_INS_ENABLE_POPUP_SLIDER = 1;
+        var YBC_INS_SLIDER_HOOK = 'home,custom';
+        var YBC_INS_GALLERY_DISPLAY_TYPE = 'grid';
+        var YBC_INS_GALLERY_LAZY = 1;
+        var YBC_INS_GALLERY_DISPLAY_FULL_WIDTH = 0;
+        var YBC_INS_GALLERY_LOADMORE_TYPE = 'scroll';
+        var YBC_INS_POPP_PER_ROW_DESKTOP = 2;
+        var YBC_INS_POPP_PER_ROW_TABLET = 2;
+        var YBC_INS_POPP_PER_ROW_MOBILE = 1;
+        var YBC_INS_POPP_ITEM_SPACING = 1;
+        var YBC_INS_POPP_HOOK_TO = 'additional_info';
+        var YBC_INS_POPP_DISPLAY_TYPE = 'carousel';
+        var YBC_INS_POPP_AUTOPLAY_CAROUSEL = 0;
+        var YBC_INS_POPP_CAROUSEL_SPEED = 2000;
+        var YBC_INS_POPP_LAZY = 1;
+        var YBC_INS_POPP_LOADMORE_TYPE = 'button';
+        var YBC_INS_POPP_ENABLED = 1;
+        var YBC_INS_TAG_PER_ROW_DESKTOP = 4;
+        var YBC_INS_TAG_PER_ROW_TABLET = 4;
+        var YBC_INS_TAG_PER_ROW_MOBILE = 2;
+        var YBC_INS_TAG_ITEM_SPACING = 0;
+        var YBC_INS_TAG_DISPLAY_TYPE = 'grid';
+        var YBC_INS_TAG_LAZY = 1;
+        var YBC_INS_TAG_DISPLAY_FULL_WIDTH = 0;
+        var YBC_INS_TAG_LOADMORE_TYPE = 'button';
+        var YBC_INS_DISPLAY_NAME = 'swisstimehouse';
+        var YBC_INS_URL = 'https://www.instagram.com/swisstimehouse/';
+        var YBC_INS_FOLLOWING_BUTTON = 'Follow us on Instagram';
+        var YBC_INS_GRAB_IT_BUTTON_PHOTO = 'View photo';
+        var YBC_INS_GALLERY_ITEM_SPACING = 0;
+        var YBC_INS_GALLERY_PER_ROW_DESKTOP = 4;
+        var YBC_INS_GALLERY_PER_ROW_TABLET = 3;
+        var YBC_INS_GALLERY_PER_ROW_MOBILE = 2;
+        var YBC_INS_DISPLAY_LIKE_COUNT = 1;
+        var YBC_INS_DISPLAY_DESCRIPTION = 1;
+        var YBC_INS_DISPLAY_SHOPNOW = 1;
+        var YBC_INS_GALLERY_NUMBER = 0;
+        var YBC_INS_GALLERY_LOADMORE = 1;
+        YBC_INS_URL_AJAX = "/?fc=module&module=ybc_instagram&controller=next";</script>
+
+<!--/Module: ybc_instagram -->
+
+            <script id="js-rcpgtm-config" type="application/json">{"bing":{"tracking_id":"56320403","feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"context":{"browser":{"device_type":4},"localization":{"id_country":110,"country_code":"IN","id_currency":1,"currency_code":"INR","id_lang":1,"lang_code":"en"},"page":{"controller_name":"product","products_per_page":25,"category":[],"search_term":""},"shop":{"id_shop":1,"shop_name":"Swiss Time House","base_dir":"https:\/\/www.swisstimehouse.com\/"},"tracking_module":{"module_name":"rcpgtagmanager","module_version":"4.4.5","checkout_module":{"module":"default","controller":"order"},"service_version":"1","token":"4aeead1b508c5c17ced838cc3ea2d17a"},"user":[]},"criteo":{"tracking_id":"","feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"facebook":{"tracking_id":"","feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"ga4":{"tracking_id":"G-E3BLHMRNRK","server_container_url":"","is_url_passthrough":true,"is_data_import":true},"gads":{"tracking_id":"958602204","merchant_id":"104996096","conversion_labels":{"create_account":"0MNfCIuxtYgDENy3jMkD","product_view":"QCGMCMuvtYgDENy3jMkD","add_to_cart":"NrxTCL2Ii4gDENy3jMkD","begin_checkout":"SaAkCN2ptYgDENy3jMkD","purchase":"6pqRCMmm-e4BENy3jMkD"},"is_custom_remarketing":true},"gtm":{"tracking_id":"GTM-TP6558P","is_internal_traffic":false,"script_url":"https:\/\/www.googletagmanager.com\/gtm.js","data_layer_name":"dataLayer","id_parameter":"id","override_tracking_id":""},"google_feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"},"kelkoo":{"tracking_list":[],"feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"pinterest":{"tracking_id":"","feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"tiktok":{"tracking_id":"","feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}},"twitter":{"tracking_id":"","events":{"add_to_cart_id":"","payment_info_id":"","checkout_initiated_id":"","product_view_id":"","lead_id":"","purchase_id":"","search_id":""},"feed":{"id_product_prefix":"","id_product_source_key":"id_product","id_variant_prefix":"","id_variant_source_key":"id_attribute"}}}</script>
+
+        <script type="text/javascript" data-keepinline="true" data-cfasync="false">
+            
+            const rcpgtm_config = document.getElementById('js-rcpgtm-config') ?
+                JSON.parse(document.getElementById('js-rcpgtm-config').textContent) :
+                {}
+            ;
+
+            if (typeof rcpgtm_config === 'object' && rcpgtm_config.gtm?.tracking_id && rcpgtm_config.context?.browser) {
+                rcpgtm_config.context.browser.user_agent = navigator.userAgent;
+                rcpgtm_config.context.browser.navigator_lang = navigator.language || navigator.userLanguage;
+                rcpgtm_config.context.browser.fingerprint = JSON.parse(window.localStorage.getItem('RCFingerprint'))?.value || window.crypto.randomUUID();
+                rcpgtm_config.context.page.fingerprint = window.crypto.randomUUID();
+                document.getElementById('js-rcpgtm-config').textContent = JSON.stringify(rcpgtm_config);
+
+                window[rcpgtm_config.gtm.data_layer_name] = window[rcpgtm_config.gtm.data_layer_name] || [];
+
+                const data_init = {
+                    config: (({ gtm, context, ...rest }) => rest)(rcpgtm_config),
+                    context: {
+                        browser: {
+                            ...rcpgtm_config.context.browser,
+                            is_internal_traffic: rcpgtm_config.gtm.is_internal_traffic
+                        },
+                        page: (({ products_per_page, ...rest }) => rest)(rcpgtm_config.context.page),
+                        localization: rcpgtm_config.context.localization,
+                        shop: rcpgtm_config.context.shop,
+                        user: rcpgtm_config.context.user,
+                    },
+                };
+
+                window[rcpgtm_config.gtm.data_layer_name].push(data_init);
+
+                (function(w,d,s,l,u,p,i){
+                    w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+                    var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+                    j.async=true;
+                    j.src=u+'?'+p+'='+i+dl;
+                    f.parentNode.insertBefore(j,f);
+                })(window, document, 'script', rcpgtm_config.gtm.data_layer_name, rcpgtm_config.gtm.script_url, rcpgtm_config.gtm.id_parameter, rcpgtm_config.gtm.override_tracking_id || rcpgtm_config.gtm.tracking_id);
+            }
+            
+        </script>
+    
+<script type="text/javascript">
+    
+        var oosn_front_controller_url = 'https://www.swisstimehouse.com/module/hioutofstocknotification/subscribe';
+        var psv = 1.7;
+        var oosn_secure_key = '4ac8520c069dff825ccfd65cb5c13956';
+        var oosn_position = 'page';
+        var quantity = 2;
+        var id_product = 125701;
+        var id_combination = 0;
+        var oosn_stock_managment = 1;
+    
+</script>
+
+<!-- Container for the Chatbase widget -->
+<div class="chat-container">
+    <div id="chat-container" style="position: relative; width: 100%; height: auto;">
+</div>
+</div>  
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Set Chatbase configuration	
+	 let isChatOpen = false;
+	 var  chatToggleIcon = document.querySelector('.chatbase-clone-button');
+        function toggleChatIcon() {
+			const labels = document.querySelectorAll('span.mdc-button__label');
+			const chatWindow = document.querySelector('#chatbase-bubble-window');
+            if (chatWindow && chatWindow.style.display === 'flex') {
+			chatToggleIcon.src = "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/20px.svg";
+			
+			labels.forEach(label => label.style.display = 'none');
+			$('#merchantwidgetiframe').show();
+			}
+			/*if (isChatOpen) {                
+                chatToggleIcon.src = "https://backend.chatbase.co/storage/v1/object/public/chat-icons/034638ea-1510-464d-ab08-ddbf9415756f/9aYxyeB8gJrt1_7U9MRGL.jpg";
+				
+            }*/ else {
+                 chatToggleIcon.src = "https://backend.chatbase.co/storage/v1/object/public/chat-icons/034638ea-1510-464d-ab08-ddbf9415756f/9aYxyeB8gJrt1_7U9MRGL.jpg";
+                //chatToggleIcon.src = "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/20px.svg";
+				
+				labels.forEach(label => label.style.display = 'block');
+				$('#merchantwidgetiframe').hide();
+            }
+            isChatOpen = !isChatOpen;
+        }
+		function checkChatWindowState() {
+				const chatWindow = document.querySelector('#chatbase-bubble-window');
+				if (chatWindow && chatWindow.style.display === 'flex') {
+					isChatOpen = true;
+				} else {
+					isChatOpen = false;
+				}
+			}
+	  const whatsappAnchor = document.querySelector('.whatsappchat-anchor');
+    
+    if (whatsappAnchor) {
+		 $('.chatbase-clone-button').hide();
+		 $('.chatbase-clone-button-mobile').hide();
+	}
+	else{
+    window.chatbaseConfig  = {
+        chatbotId: 'nTrBoJlHiFH8k6oHKk2EK',
+        domain: 'www.chatbase.co',
+		showFloatingInitialMessages: false,
+    floatingInitialMessagesDelay: 0
+    };    
+    function loadChatbaseInContainer(containerId) {
+        const container = document.getElementById(containerId);
+        if (container) {
+            const script = document.createElement('script');
+            script.src = "https://www.chatbase.co/embed.min.js";
+            script.defer = true;
+            script.onload = () => console.log("Chatbase widget loaded in specified container.");
+            container.appendChild(script);
+        } else {
+            
+        }
+    }    
+    //document.addEventListener('DOMContentLoaded', function() {
+        loadChatbaseInContainer("chat-container");        
+		let isMonitoringStarted = false; 
+        const mobileCloneButton = document.querySelector('.chatbase-clone-button-mobile');
+        if (mobileCloneButton) {
+            mobileCloneButton.addEventListener('click', function() {
+                document.getElementById('chatbase-bubble-button')?.click();
+				if (!isMonitoringStarted) {
+            isMonitoringStarted = true; // Set the flag to prevent reinitialization
+            monitorChatBubble('#chatbase-bubble-window', chatBubbleStatusHandler);
+        }
+		const chatWindow = document.getElementById('chatbase-bubble-window');
+		if (chatWindow) {
+		  chatWindow.style.zIndex = '9999999999'; // Apply high z-index
+		  console.log('z-index set for #chatbase-bubble-window');}
+		   });
+        }        
+        const desktopCloneButton = document.querySelector('.chatbase-clone-button');
+        if (desktopCloneButton) {
+            desktopCloneButton.addEventListener('click', function() {
+				//checkChatWindowState();
+                document.getElementById('chatbase-bubble-button')?.click();
+				toggleChatIcon();
+            });
+        }
+    //});
+	 function monitorChatBubble(windowId, callback) {
+    // Select the chat bubble container
+    const chatBubbleWindow = document.querySelector(windowId);
+
+    if (!chatBubbleWindow) {
+        console.error('Element with ID' +windowId+ 'not found in the DOM');
+        return;
+    }
+
+    // Create a MutationObserver to monitor changes
+    const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+            if (mutation.attributeName === 'style') {
+                // Check if the chat bubble is visible or hidden
+                const isVisible = window.getComputedStyle(chatBubbleWindow).display !== 'none';
+                callback(isVisible); // Call the provided callback with visibility status
+            }
+        }
+    });
+
+    // Configure the observer to watch for style attribute changes
+    observer.observe(chatBubbleWindow, {
+        attributes: true, // Watch for attribute changes
+        attributeFilter: ['style'], // Only watch the 'style' attribute
+    });
+	const iframe = document.querySelector('div#merchantwidget-iframe-wrapper iframe');
+            if (iframe) {
+                iframe.style.display = 'none';
+            }
+    console.log('Monitoring visibility changes for' +windowId);
+}
+// Define a callback function
+    const iframe = document.querySelector('div#merchantwidget-iframe-wrapper iframe');
+function chatBubbleStatusHandler(isVisible) {
+    if (isVisible) {
+	console.log('chat open');
+            if (iframe) {
+                iframe.style.display = 'none';
+            }
+    } else {
+        if (iframe) {
+                iframe.style.display = 'block';
+            }
+    }
+}
+
+	}
+   });
+   
+   
+   
+</script>
+
+<style>
+    
+    #chatbase-bubble-button {
+        display: none !important;
+    }
+	.desktop-custom-menu  .elementor-spacer-inner {
+    display: none;
+	}
+</style>
+
+
+
+
+
+      <link rel="preload" as="image" href="https://www.swisstimehouse.com/img/swiss-time-house-logo-1665736482.jpg">
+    
+  
+  <link
+      rel="preload"
+      href="https://www.swisstimehouse.com/themes/falcon/assets/fonts/roboto-v20-latin-ext_latin-regular-5cb5c8f08bb4e6cb64c3b5b6115bf498.woff2"
+      as="font"
+      crossorigin
+    ><link
+      rel="preload"
+      href="https://www.swisstimehouse.com/themes/falcon/assets/fonts/roboto-v20-latin-ext_latin-500-0b45721325446d537b545d6224819ad4.woff2"
+      as="font"
+      crossorigin
+    ><link
+      rel="preload"
+      href="https://www.swisstimehouse.com/themes/falcon/assets/fonts/roboto-v20-latin-ext_latin-700-1d1ef7788f0ff084b8811576cb59df57.woff2"
+      as="font"
+      crossorigin
+    ><link
+      rel="preload"
+      href="https://www.swisstimehouse.com/themes/falcon/assets/fonts/MaterialIcons-Regular-12a47ed5fd5585f0f4227fa035a1a607.woff2"
+      as="font"
+      crossorigin
+    ><link
+      rel="preload"
+      href="https://www.swisstimehouse.com/themes/falcon/assets/fonts/icomoon-d7aecaf7d15cbb1a5968007421e0052f.woff2"
+      as="font"
+      crossorigin
+    >
+
+
+
+
+  
+
+
+
+
+  	
+
+
+
+  <script type="text/javascript">
+        var blockwishlistController = "https:\/\/www.swisstimehouse.com\/module\/blockwishlist\/action";
+        var iqitmegamenu = {"sticky":"false","containerSelector":"#wrapper > .container"};
+        var is_store_selction = false;
+        var jolisearch = {"amb_joli_search_action":"https:\/\/www.swisstimehouse.com\/jolisearch","amb_joli_search_link":"https:\/\/www.swisstimehouse.com\/jolisearch","amb_joli_search_controller":"jolisearch","blocksearch_type":"top","show_cat_desc":0,"ga_acc":0,"id_lang":1,"url_rewriting":1,"use_autocomplete":2,"minwordlen":2,"l_products":"Products","l_manufacturers":"Manufacturers","l_categories":"Categories","l_no_results_found":"No results found","l_more_results":"More results \u00bb","ENT_QUOTES":3,"search_ssl":true,"self":"\/var\/www\/vhosts\/swisstimehouse.com\/httpdocs\/modules\/ambjolisearch","position":{"my":"center top","at":"center bottom","collision":"fit none"},"classes":"ps17 centered-list","display_manufacturer":"1","display_category":""};
+        var listDisplayAjaxUrl = "https:\/\/www.swisstimehouse.com\/module\/is_themecore\/ajaxTheme";
+        var oosn_id_module = "302";
+        var placeholder_label = "Start typing here";
+        var prestashop = {"cart":{"products":[],"totals":{"total":{"type":"total","label":"Total","amount":0,"value":"\u20b9 0"},"total_including_tax":{"type":"total","label":"Total (tax incl.)","amount":0,"value":"\u20b9 0"},"total_excluding_tax":{"type":"total","label":"Total (tax excl.)","amount":0,"value":"\u20b9 0"}},"subtotals":{"products":{"type":"products","label":"Subtotal","amount":0,"value":"\u20b9 0"},"discounts":null,"shipping":{"type":"shipping","label":"Shipping","amount":0,"value":""},"tax":null},"products_count":0,"summary_string":"0 items","vouchers":{"allowed":1,"added":[]},"discounts":[],"minimalPurchase":0,"minimalPurchaseRequired":""},"currency":{"id":1,"name":"Indian Rupee","iso_code":"INR","iso_code_num":"356","sign":"\u20b9"},"customer":{"lastname":null,"firstname":null,"email":null,"birthday":null,"newsletter":null,"newsletter_date_add":null,"optin":null,"website":null,"company":null,"siret":null,"ape":null,"is_logged":false,"gender":{"type":null,"name":null},"addresses":[]},"language":{"name":"English (English)","iso_code":"en","locale":"en-US","language_code":"en-us","is_rtl":"0","date_format_lite":"m\/d\/Y","date_format_full":"m\/d\/Y H:i:s","id":1},"page":{"title":"","canonical":"https:\/\/www.swisstimehouse.com\/casio-g1714","meta":{"title":"Buy Casio Casio G1714 Watch in India I Swiss Time House","description":"Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu...","keywords":"buy Casio Casio G1714 online, shop Casio watch, Casio G1714, shop G1714, shop Casio at lowest price, G-Shock Watches , Casio  Casio G1714","robots":"index"},"page_name":"product","body_classes":{"lang-en":true,"lang-rtl":false,"country-IN":true,"currency-INR":true,"layout-full-width":true,"page-product":true,"tax-display-enabled":true,"product-id-125701":true,"product-Casio G1714 - GM-B2100SD-1CDR G-Shock Watch":true,"product-id-category-281":true,"product-id-manufacturer-21":true,"product-id-supplier-0":true,"product-available-for-order":true},"admin_notifications":[]},"shop":{"name":"Swiss Time House","logo":"https:\/\/www.swisstimehouse.com\/img\/swiss-time-house-logo-1665736482.jpg","stores_icon":"https:\/\/www.swisstimehouse.com\/img\/logo_stores.png","favicon":"https:\/\/www.swisstimehouse.com\/img\/favicon.ico"},"urls":{"base_url":"https:\/\/www.swisstimehouse.com\/","current_url":"https:\/\/www.swisstimehouse.com\/casio-g1714","shop_domain_url":"https:\/\/www.swisstimehouse.com","img_ps_url":"https:\/\/www.swisstimehouse.com\/img\/","img_cat_url":"https:\/\/www.swisstimehouse.com\/img\/c\/","img_lang_url":"https:\/\/www.swisstimehouse.com\/img\/l\/","img_prod_url":"https:\/\/www.swisstimehouse.com\/img\/p\/","img_manu_url":"https:\/\/www.swisstimehouse.com\/img\/m\/","img_sup_url":"https:\/\/www.swisstimehouse.com\/img\/su\/","img_ship_url":"https:\/\/www.swisstimehouse.com\/img\/s\/","img_store_url":"https:\/\/www.swisstimehouse.com\/img\/st\/","img_col_url":"https:\/\/www.swisstimehouse.com\/img\/co\/","img_url":"https:\/\/www.swisstimehouse.com\/themes\/falcon-child\/assets\/img\/","css_url":"https:\/\/www.swisstimehouse.com\/themes\/falcon-child\/assets\/css\/","js_url":"https:\/\/www.swisstimehouse.com\/themes\/falcon-child\/assets\/js\/","pic_url":"https:\/\/www.swisstimehouse.com\/upload\/","pages":{"address":"https:\/\/www.swisstimehouse.com\/address","addresses":"https:\/\/www.swisstimehouse.com\/addresses","authentication":"https:\/\/www.swisstimehouse.com\/login","cart":"https:\/\/www.swisstimehouse.com\/cart","category":"https:\/\/www.swisstimehouse.com\/index.php?controller=category","cms":"https:\/\/www.swisstimehouse.com\/index.php?controller=cms","contact":"https:\/\/www.swisstimehouse.com\/contact-us","discount":"https:\/\/www.swisstimehouse.com\/discount","guest_tracking":"https:\/\/www.swisstimehouse.com\/guest-tracking","history":"https:\/\/www.swisstimehouse.com\/order-history","identity":"https:\/\/www.swisstimehouse.com\/identity","index":"https:\/\/www.swisstimehouse.com\/","my_account":"https:\/\/www.swisstimehouse.com\/my-account","order_confirmation":"https:\/\/www.swisstimehouse.com\/order-confirmation","order_detail":"https:\/\/www.swisstimehouse.com\/index.php?controller=order-detail","order_follow":"https:\/\/www.swisstimehouse.com\/order-follow","order":"https:\/\/www.swisstimehouse.com\/order","order_return":"https:\/\/www.swisstimehouse.com\/index.php?controller=order-return","order_slip":"https:\/\/www.swisstimehouse.com\/order-slip","pagenotfound":"https:\/\/www.swisstimehouse.com\/page-not-found","password":"https:\/\/www.swisstimehouse.com\/password-recovery","pdf_invoice":"https:\/\/www.swisstimehouse.com\/index.php?controller=pdf-invoice","pdf_order_return":"https:\/\/www.swisstimehouse.com\/index.php?controller=pdf-order-return","pdf_order_slip":"https:\/\/www.swisstimehouse.com\/index.php?controller=pdf-order-slip","prices_drop":"https:\/\/www.swisstimehouse.com\/prices-drop","product":"https:\/\/www.swisstimehouse.com\/index.php?controller=product","search":"https:\/\/www.swisstimehouse.com\/search","sitemap":"https:\/\/www.swisstimehouse.com\/sitemap","stores":"https:\/\/www.swisstimehouse.com\/stores","supplier":"https:\/\/www.swisstimehouse.com\/supplier","register":"https:\/\/www.swisstimehouse.com\/login?create_account=1","order_login":"https:\/\/www.swisstimehouse.com\/order?login=1"},"alternative_langs":[],"theme_assets":"\/themes\/falcon-child\/assets\/","actions":{"logout":"https:\/\/www.swisstimehouse.com\/?mylogout="},"no_picture_image":{"bySize":{"small_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-small_default.jpg","width":98,"height":127},"cart_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-cart_default.jpg","width":125,"height":162},"large_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-large_default.jpg","width":419,"height":541},"home_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-home_default.jpg","width":440,"height":569},"medium_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-medium_default.jpg","width":452,"height":584},"thickbox_default":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-thickbox_default.jpg","width":1100,"height":1422}},"small":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-small_default.jpg","width":98,"height":127},"medium":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-home_default.jpg","width":440,"height":569},"large":{"url":"https:\/\/www.swisstimehouse.com\/img\/p\/en-default-thickbox_default.jpg","width":1100,"height":1422},"legend":""}},"configuration":{"display_taxes_label":true,"display_prices_tax_incl":true,"is_catalog":false,"show_prices":true,"opt_in":{"partner":false},"quantity_discount":{"type":"discount","label":"Unit discount"},"voucher_enabled":1,"return_enabled":0},"field_required":[],"breadcrumb":{"links":[{"title":"Home","url":"https:\/\/www.swisstimehouse.com\/"},{"title":"Products","url":"https:\/\/www.swisstimehouse.com\/products"},{"title":"Watches","url":"https:\/\/www.swisstimehouse.com\/watches"},{"title":"Accessible & Desirable Brands","url":"https:\/\/www.swisstimehouse.com\/accessible-desirable-brands"},{"title":"Casio Watches","url":"https:\/\/www.swisstimehouse.com\/casio-watches"},{"title":"G-Shock Watches","url":"https:\/\/www.swisstimehouse.com\/g-shock-watches"},{"title":"Casio G1714 - GM-B2100SD-1CDR G-Shock Watch","url":"https:\/\/www.swisstimehouse.com\/casio-g1714"}],"count":7},"link":{"protocol_link":"https:\/\/","protocol_content":"https:\/\/"},"time":1780145621,"static_token":"7c0cb7b2271365cbe5adb02c6fafe304","token":"62db07c0acbfc8f710c93bfde48c6aaf","debug":false};
+        var prestashopFacebookAjaxController = "https:\/\/www.swisstimehouse.com\/module\/ps_facebook\/Ajax";
+        var productsAlreadyTagged = [];
+        var psemailsubscription_subscription = "https:\/\/www.swisstimehouse.com\/module\/ps_emailsubscription\/subscription";
+        var removeFromWishlistUrl = "https:\/\/www.swisstimehouse.com\/module\/blockwishlist\/action?action=deleteProductFromWishlist";
+        var search_url = "https:\/\/www.swisstimehouse.com\/find-product";
+        var stwebp = {"cart_default":1,"category_default":1,"home_default":1,"large_default":1,"medium_default":1,"small_default":1,"stores_default":1,"thickbox_default":1};
+        var stwebp_supported = null;
+        var stwebp_type = 0;
+        var wishlistAddProductToCartUrl = "https:\/\/www.swisstimehouse.com\/module\/blockwishlist\/action?action=addProductToCart";
+        var wishlistUrl = "https:\/\/www.swisstimehouse.com\/module\/blockwishlist\/view";
+      </script>
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/themes/falcon-child/assets/css/theme.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ps_socialfollow/views/css/ps_socialfollow.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/swiper/css/swiper.min.css?v=11.2.10" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/frontend.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-product-images.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-product.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-product-meta.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-countdown.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-form.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-product-quantity.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-social-icons.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-icon-list.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-divider.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-icon-box.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-image-carousel.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-product-box.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-call-to-action.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/conditionals/transitions.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-nav-menu.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-ajax-search.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-shopping-cart.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-alert.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/widget-email-subscription.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Figtree:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CDM+Serif+Text:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CInter:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CQuicksand:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CPlayfair+Display:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CMontserrat:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CWork+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CLato:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic%7CManrope:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic&amp;display=swap" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/font-awesome/css/solid.min.css?v=6.2.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/ceicons/ceicons.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/font-awesome/css/brands.min.css?v=6.4.2" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/font-awesome/css/regular.min.css?v=6.2.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/animations/animations.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/lib/ceicons/ceicons.min.css?v=2.14.0" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/ce/kit-14.css?v=1772507429" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/ce/28170101.css?v=1774543042" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/ce/36170101.css?v=1772359738" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/ce/27170101.css?v=1773126823" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/creativeelements/views/css/ce/1-global.css?v=1766995309" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/cashondeliveryfeeplus//views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/steasycheckout/views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/steasycheckout/views/font/fontello-codes.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/trackdelhivery//views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/returnmanager/views/css/velsof_rm_spinner.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ambjolisearch/views/css/jolisearch-common.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ambjolisearch/views/css/jolisearch-finder.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/trackbluedart//views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/spmgsnipreview.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/spmgsnipreview17.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/font-custom.min.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/users.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/storereviews.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/widgets.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/owl.carousel.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/spmgsnipreview/views/css/owl.theme.default.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/storelocator/views/css/easy-autocomplete.min.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/storelocator/views/css/stores.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ybc_instagram/views/css/ets.fancybox.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ybc_instagram/views/css/instagram.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ybc_instagram/views/css/fix17.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/ybc_instagram/views/css/slick.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/hioutofstocknotification/views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/hioutofstocknotification/views/css/custom.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/watiwhatsapp/views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/js/jquery/ui/themes/base/minified/jquery-ui.min.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/js/jquery/ui/themes/base/minified/jquery.ui.theme.min.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/blockwishlist/public/wishlist.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/js/jquery/plugins/fancybox/jquery.fancybox.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/callforprice/views/css/callforprice.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/callforprice/views/css/codemirror_custom.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/iqitmegamenu/views/css/front.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/otplogin/views/css/style.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/modules/iqitmegamenu/views/css/iqitmegamenu_s_1.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/themes/falcon-child/assets/css/product.css" media="all">
+		<link rel="stylesheet" href="https://www.swisstimehouse.com/themes/falcon/assets/css/custom.css" media="all">
+	
+	
+
+
+	<script>
+			var ceFrontendConfig = {"environmentMode":{"edit":false,"isScriptDebug":false},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"hasCustomBreakpoints":false},"version":"2.14.0","urls":{"assets":"\/\/www.swisstimehouse.com\/modules\/creativeelements\/views\/"},"i18n":{"close":"Close","zoom":"Zoom","fullscreen":"Fullscreen","prevSlideMessage":"Previous","nextSlideMessage":"Next","paginationBulletMessage":"Go To {{index}}"},"productQuickView":0,"settings":{"page":[],"general":{"elementor_global_image_lightbox":"1","elementor_lightbox_enable_counter":"yes","elementor_lightbox_enable_fullscreen":"yes","elementor_lightbox_enable_zoom":"yes","elementor_lightbox_title_src":"title","elementor_lightbox_description_src":"caption"},"editorPreferences":[]},"post":{"id":"125701030101","title":"Casio%20G1714%20-%20GM-B2100SD-1CDR%20G-Shock%20Watch","excerpt":""}};
+		</script>
+        <link rel="preload" href="/modules/creativeelements/views/lib/ceicons/fonts/ceicons.woff2?8goggd" as="font" type="font/woff2" crossorigin>
+        
+
+
+	
+			<script type="application/ld+json">
+{
+	"@context": "https://schema.org/",
+	"@type": "Product",
+	"name": "Casio G1714 - GM-B2100SD-1CDR G-Shock Watch",
+	"description": "Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu...",
+	"category": "G-Shock Watches",
+	"image" :"https://www.swisstimehouse.com/196159-home_default/casio-g1714.jpg",
+	"sku": "G1714",
+	"mpn": "G1714",
+	"gtin13": "4549526401541",
+	"brand": {
+		"@type": "Brand",
+		"name": "Casio"
+	},
+	"weight": {
+			"@context": "https://schema.org",
+			"@type": "QuantitativeValue",
+			"value": "0.000000",
+			"unitCode": "kg"
+	},
+	"offers": {
+		"@type": "Offer",
+		"priceCurrency": "INR",
+		"name": "Casio G1714 - GM-B2100SD-1CDR G-Shock Watch",
+		"price": "34997",
+		"url": "https://www.swisstimehouse.com/casio-g1714",
+		"priceValidUntil": "2026-06-14",
+			"image": ["https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg","https://www.swisstimehouse.com/196160-thickbox_default/casio-g1714.jpg","https://www.swisstimehouse.com/196161-thickbox_default/casio-g1714.jpg","https://www.swisstimehouse.com/196162-thickbox_default/casio-g1714.jpg","https://www.swisstimehouse.com/196163-thickbox_default/casio-g1714.jpg"],
+			"sku": "G1714",
+		"mpn": "G1714",
+			"gtin13": "4549526401541",
+				"availability": "https://schema.org/InStock",
+		"seller": {
+			"@type": "Organization",
+			"name": "Swiss Time House"
+		}
+	},
+	"url": "https://www.swisstimehouse.com/casio-g1714"
+}
+</script>	
+	<meta property="og:type" content="product">
+				<meta property="og:image" content="https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg">
+				<meta property="product:pretax_price:amount" content="34997">
+		<meta property="product:pretax_price:currency" content="INR">
+		<meta property="product:price:amount" content="34997">
+		<meta property="product:price:currency" content="INR">
+				<meta property="product:weight:value" content="0.000000">
+		<meta property="product:weight:units" content="kg">
+		
+</head>
+<body id="product" class="lang-en country-in currency-inr page-product tax-display-enabled product-id-125701 product-casio-g1714-gm-b2100sd-1cdr-g-shock-watch product-id-category-281 product-id-manufacturer-21 product-id-supplier-0 product-available-for-order ce-kit-14 elementor-page elementor-page-125701030101 ce-theme ce-theme-28 layout-header-footer">
+	
+		
+	
+	<main>
+		
+					
+		<header id="header" class="header">
+			
+					        <div data-elementor-type="header" data-elementor-id="36170101" class="elementor elementor-36170101">
+            <div class="elementor-section-wrap">
+                        <section class="elementor-element elementor-element-1c80096c elementor-section-content-middle elementor-section-full_width top-announcement-bar elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="1c80096c" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-15d3e86b elementor-hidden-phone elementor-column elementor-col-33 elementor-top-column" data-id="15d3e86b" data-element_type="column">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-7137828c elementor-column elementor-col-33 elementor-top-column" data-id="7137828c" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-64ad4b69 elementor-widget elementor-widget-heading" data-id="64ad4b69" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><span class="elementor-heading-title"><!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rotating Banner</title>
+  <style>
+    .scrolling-banner {
+      width: 100%;
+      height: 30px;
+      background-color: #000000;
+      overflow: hidden;
+      position: relative;
+      font-family: inherit;
+      white-space: nowrap;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .banner-content {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      padding: 0 60px;
+      width: 100%;
+      text-align: center;
+      box-sizing: border-box;
+      opacity: 1;
+      transition: opacity 0.5s ease; /* fade */
+    }
+
+    .fade-out {
+      opacity: 0;
+    }
+
+    .fade-in {
+      opacity: 1;
+    }
+
+    .banner-content span,
+    .banner-content a {
+      color: #ffffff !important;
+      text-decoration: none;
+    }
+
+    .nav-arrow {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 30px;
+      text-align: center;
+      cursor: pointer;
+      font-size: 16px;
+      color: #ffffff;
+      user-select: none;
+    }
+
+    .nav-arrow.left {
+      left: 10px;
+    }
+
+    .nav-arrow.right {
+      right: 10px;
+    }
+
+    .nav-arrow:hover {
+      opacity: 0.8;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="scrolling-banner">
+    <div class="nav-arrow left" id="prevArrow">&#8249;</div>
+    <div class="banner-content" id="bannerContent"></div>
+    <div class="nav-arrow right" id="nextArrow">&#8250;</div>
+  </div>
+
+  <script>
+    const messages = [
+      `INDIA'S TRUSTED WATCH STORE <a href="https://www.swisstimehouse.com/products">SINCE 1946</a>`,
+      `SAVE MORE WITH CODE - <a href="https://www.swisstimehouse.com/products">SHOPNOW</a>`,
+      `EXPLORE <a href="https://www.swisstimehouse.com/prices-drop">GREAT OFFERS & HOT DEALS</a>`,
+      `<a href="https://www.swisstimehouse.com/products">FREE DELIVERY</a> ACROSS INDIA`,
+      `<a href="https://www.swisstimehouse.com/our-stores">Over 60</a> stores across India`
+    ];
+
+    const contentEl = document.getElementById('bannerContent');
+    const prevArrow = document.getElementById('prevArrow');
+    const nextArrow = document.getElementById('nextArrow');
+
+    let currentIndex = 0;
+    const intervalMs = 3000;
+    let rotationTimer = null;
+
+    function renderWithFade(newIndex) {
+      contentEl.classList.add('fade-out');
+
+      setTimeout(() => {
+        currentIndex = newIndex;
+        contentEl.innerHTML = `<span>${messages[currentIndex]}</span>`;
+        contentEl.classList.remove('fade-out');
+        contentEl.classList.add('fade-in');
+
+        setTimeout(() => {
+          contentEl.classList.remove('fade-in');
+        }, 500);
+      }, 500);
+    }
+
+    function showNext() {
+      renderWithFade((currentIndex + 1) % messages.length);
+    }
+
+    function showPrev() {
+      renderWithFade((currentIndex - 1 + messages.length) % messages.length);
+    }
+
+    function startAutoRotation() {
+      if (rotationTimer) clearInterval(rotationTimer);
+      rotationTimer = setInterval(showNext, intervalMs);
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      contentEl.innerHTML = `<span>${messages[currentIndex]}</span>`;
+      startAutoRotation();
+
+      nextArrow.addEventListener('click', () => {
+        showNext();
+        startAutoRotation();
+      });
+
+      prevArrow.addEventListener('click', () => {
+        showPrev();
+        startAutoRotation();
+      });
+    });
+  </script>
+
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js/v833ccba57c9e4d2798f2e76cebdd09a11778172276447" integrity="sha512-57MDmcccJXYtNnH+ZiBwzC4jb2rvgVCEokYN+L/nLlmO8rfYT/gIpW2A569iJ/3b+0UEasghjuZH/ma3wIs/EQ==" data-cf-beacon='{"version":"2024.11.0","token":"8e9a39ce358849d8972527df8ce1a722","server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+</body>
+</html>
+</span></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-3eeec8c5 elementor-hidden-phone elementor-column elementor-col-33 elementor-top-column" data-id="3eeec8c5" data-element_type="column">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-441c19e2 elementor-section-content-middle elementor-section-height-min-height elementor-section-full_width header_main elementor-section-height-default elementor-section-items-middle elementor-section elementor-top-section" data-id="441c19e2" data-element_type="section" data-settings="{&quot;sticky&quot;:&quot;top&quot;,&quot;sticky_on&quot;:[&quot;desktop&quot;,&quot;tablet&quot;,&quot;mobile&quot;],&quot;sticky_offset&quot;:0,&quot;sticky_effects_offset&quot;:0}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-5abbb724 elementor-hidden-desktop elementor-hidden-tablet elementor-column elementor-col-25 elementor-top-column" data-id="5abbb724" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-7f901590 elementor-nav--stretch elementor-widget__width-auto elementor-hidden-desktop elementor-widget-tablet__width-auto elementor-widget-mobile__width-auto mobile_menu elementor-nav--text-align-aside elementor-nav--toggle elementor-nav--burger elementor-widget elementor-widget-nav-menu" data-id="7f901590" data-element_type="widget" data-settings="{&quot;layout&quot;:&quot;dropdown&quot;,&quot;full_width&quot;:&quot;stretch&quot;,&quot;submenu_icon&quot;:{&quot;value&quot;:&quot;fas fa-angle-down&quot;,&quot;library&quot;:&quot;fa-solid&quot;},&quot;show_submenu_on&quot;:&quot;hover&quot;,&quot;animation_dropdown&quot;:&quot;toggle&quot;,&quot;toggle&quot;:&quot;burger&quot;}" data-widget_type="nav-menu.default">
+        <div class="elementor-widget-container">        <a href="javascript://toggle" class="elementor-menu-toggle" role="button" aria-label="Menu" aria-expanded="false">
+            <i class="ceicon ceicon-menu" aria-hidden="true"></i>
+        </a>
+        <nav class="elementor-nav--dropdown elementor-nav__container" aria-label="Main Menu">        <ul class="elementor-nav" id="menu-2-7f901590">
+		<li class="logo_menu">
+        <img src="/img/swiss-time-house-logo-1665736482.jpg" /><div class="close_menu">
+        <i class="ceicon-close"></i>
+</div>
+      </li>                    <li class="menu-item menu-item-type-link menu-item-lnk-homepage">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/">
+                                    Homepage                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-12 menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/watches">
+                                    Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-140 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/luxury-brands">
+                                    Luxury & Premium Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-72">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/balmain-watches">
+                                    Balmain Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-354">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/movado-watches">
+                                    Movado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-watches">
+                                    Seiko Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-74">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/longines-watches">
+                                    Longines Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-73">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/omega-watches">
+                                    Omega Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rado-watches">
+                                    Rado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tag-heuer-watches">
+                                    Tag Heuer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-33">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tissot-watches">
+                                    Tissot Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-47">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-watches">
+                                    Victorinox Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-113">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rolex-watches">
+                                    Rolex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-327">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sevenfriday-watches">
+                                    SevenFriday Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-337">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/franck-muller-watches">
+                                    Franck Muller Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-848">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/gc-watches">
+                                    Gc Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-137 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fashion-brands">
+                                    Fashion Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-116">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/armani-exchange-watches">
+                                    Armani Exchange Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-355">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/hugo-boss-watches">
+                                    Hugo Boss Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calvin-klein-watches">
+                                    Calvin Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-18">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/diesel-watches">
+                                    Diesel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-915">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tornado-watches">
+                                    Tornado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-918">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/aston-martin-watches">
+                                    Aston Martin Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-920">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/off-road-watches">
+                                    Off Road Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/emporio-armani-watches">
+                                    Emporio Armani Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-913">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rock-revival-watches">
+                                    Rock Revival Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-917">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jean-fendi-watches">
+                                    Jean Fendi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-910">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/foce-watches">
+                                    Foce Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-32">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/esprit-watches">
+                                    Esprit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-148">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/giordano-watches">
+                                    Giordano Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-183">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-watches">
+                                    Kenneth Cole Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-149">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/michael-kors-watches">
+                                    Michael Kors Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-23">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/police-watches">
+                                    Police Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-107">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skagen-watches">
+                                    Skagen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-35">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/swatch-watches">
+                                    Swatch Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-24">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tommy-hilfiger-watches">
+                                    Tommy Hilfiger Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-256">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-watches">
+                                    Fossil Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-101">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/alba-watches">
+                                    Alba Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-262">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/obaku-watches">
+                                    Obaku Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-323">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/anne-klein-watches">
+                                    Anne Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-324">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/earnshaw-watches">
+                                    Earnshaw Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-326">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/strand-watches">
+                                    Strand Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-342">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/coach-watches">
+                                    Coach Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-351">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/guess-watches">
+                                    Guess Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-353">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/daniel-wellington-watches">
+                                    Daniel Wellington Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-22">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/citizen-watches">
+                                    Citizen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-850">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/quantum-watches">
+                                    Quantum Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-903">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/cerruti-watches">
+                                    Cerruti Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-142 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessible-desirable-brands">
+                                    Accessible & Desirable Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-watches">
+                                    Fastrack Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/qnq-watches">
+                                    Q&Q Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-64">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sonata-watches">
+                                    Sonata Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-318">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/horo-watches">
+                                    Horo Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-852">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tickid-watches">
+                                    Tickid Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-27">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/timex-watches">
+                                    Timex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-122">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/westar-watches">
+                                    Westar Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zoop-watches">
+                                    Zoop Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-119">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/helix-watches">
+                                    Helix Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-41 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-watches">
+                                    Casio Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-247">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sheen-watches">
+                                    Sheen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-248">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/baby-g-watches">
+                                    Baby-G Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-250">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/youth-watches">
+                                    Youth Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-252">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/outdoor-watches">
+                                    Outdoor Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-266">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/enticer-watches">
+                                    Enticer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-253">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watches">
+                                    Smart Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-267">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/protrek-watches">
+                                    Protrek Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-268">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/vintage-watches">
+                                    Vintage Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-281">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/g-shock-watches">
+                                    G-Shock Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-282">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/edifice-watches">
+                                    Edifice Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-26">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-watches">
+                                    Titan Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-904">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-watches">
+                                    Jack & Jill Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-842 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watch-brands">
+                                    Smart Watch Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-320">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/firebolt-watches">
+                                    Firebolt Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-302">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-watches">
+                                    Mi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-315">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/beetel-watches">
+                                    Beetel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-341">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/techlog-watches">
+                                    TechLog Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-345">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/boat-watches">
+                                    Boat Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-348">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/amazfit-watches">
+                                    Amazfit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-845">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/just-corseca-watches">
+                                    Just Corseca Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-men">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/product-catalogue/mens-watches">
+                                    Men                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-women">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/product-catalogue/womens-watches">
+                                    Women                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturers menu-item-manufacturers menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/manufacturers">
+                                    All brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-44">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/alba">
+                                    Alba                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-192">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/amazfit">
+                                    Amazfit                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-172">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/anne-klein">
+                                    Anne Klein                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-130">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/armani-exchange">
+                                    Armani Exchange                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-218">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/aston-martin">
+                                    Aston Martin                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/balmain">
+                                    Balmain                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-169">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/beetel">
+                                    Beetel                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-187">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/boat">
+                                    Boat                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-15">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/calvin-klein">
+                                    Calvin Klein                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/casio">
+                                    Casio                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-208">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/cerruti">
+                                    Cerruti                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-8">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/citizen">
+                                    Citizen                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-186">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/coach">
+                                    Coach                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-199">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/d-time">
+                                    D Time                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-195">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/daniel-wellington">
+                                    Daniel Wellington                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-5">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/diesel">
+                                    Diesel                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-173">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/earnshaw">
+                                    Earnshaw                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-11">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/emporio-armani">
+                                    Emporio Armani                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-14">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/esprit">
+                                    Esprit                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-6">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/fastrack">
+                                    Fastrack                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-170">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/firebolt">
+                                    Firebolt                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-211">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/foce">
+                                    Foce                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-159">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/fossil">
+                                    Fossil                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-182">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/franck-muller">
+                                    Franck Muller                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-200">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/gc">
+                                    GC                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-137">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/giordano">
+                                    Giordano                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-194">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/guess">
+                                    Guess                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/helix">
+                                    Helix                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-167">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/horo">
+                                    Horo                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-196">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/hugo-boss">
+                                    Hugo Boss                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-217">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/hugo-boss-watch">
+                                    Hugo Boss Watch                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-210">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/jack-jill">
+                                    Jack & Jill                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-213">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/jean-fendi">
+                                    Jean Fendi                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-198">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/just-corseca">
+                                    Just Corseca                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-147">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/kenneth-cole">
+                                    Kenneth Cole                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-40">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/longines">
+                                    Longines                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-126">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/mi">
+                                    Mi                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-144">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/michael-kors">
+                                    Michael Kors                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-197">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/movado">
+                                    Movado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-162">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/mq">
+                                    MQ                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-161">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/obaku">
+                                    Obaku                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-219">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/off-road">
+                                    Off Road                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/omega">
+                                    Omega                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/opal">
+                                    Opal                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-212">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/paul-design">
+                                    Paul Design                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-9">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/police">
+                                    Police                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-20">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/qq">
+                                    Q&Q                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-202">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/quantum">
+                                    Quantum                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-2">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rado">
+                                    Rado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-79">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rhythm">
+                                    Rhythm                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-214">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rock-revival">
+                                    Rock Revival                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-158">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sage">
+                                    Sage                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-7">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/seiko">
+                                    Seiko                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-215">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/seven-friday">
+                                    Seven Friday                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-176">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sevenfriday">
+                                    SevenFriday                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-45">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/skagen">
+                                    Skagen                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-171">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/skin">
+                                    Skin                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-30">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sonata">
+                                    Sonata                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-175">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/strand">
+                                    Strand                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-16">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/swatch">
+                                    Swatch                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tag-heuer">
+                                    Tag Heuer                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-185">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/techlog">
+                                    TechLog                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-204">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tickid">
+                                    Tickid                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/timex">
+                                    Timex                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-17">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tissot">
+                                    Tissot                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-12">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/titan">
+                                    Titan                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-10">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tommy-hilfiger">
+                                    Tommy Hilfiger                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-216">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tornado">
+                                    Tornado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-28">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/victorinox">
+                                    Victorinox                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-87">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/westar">
+                                    Westar                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-209">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/x-hour">
+                                    X-Hour                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-207">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/zippo">
+                                    Zippo                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/zoop">
+                                    Zoop                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-3 menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/products">
+                                    Products                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-8 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/clocks">
+                                    Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-916">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/d-time-clocks">
+                                    D Time Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-854 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/wall-clocks">
+                                    Wall Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-121">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rhythm-clocks">
+                                    Rhythm Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-150">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-clocks">
+                                    Seiko Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-249">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-clocks">
+                                    Casio Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-37">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/opal-clocks">
+                                    Opal Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-905">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/x-hour-clocks">
+                                    X-Hour Clocks                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-855 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/grand-father-clocks">
+                                    Grand Father Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-846">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/d-time-grand-father-clocks">
+                                    D Time Grand Father Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-294">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mq-grand-father-clocks">
+                                    Mq Grand Father Clocks                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-12 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/watches">
+                                    Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-140 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/luxury-brands">
+                                    Luxury & Premium Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-72">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/balmain-watches">
+                                    Balmain Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-354">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/movado-watches">
+                                    Movado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-watches">
+                                    Seiko Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-74">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/longines-watches">
+                                    Longines Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-73">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/omega-watches">
+                                    Omega Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rado-watches">
+                                    Rado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tag-heuer-watches">
+                                    Tag Heuer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-33">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tissot-watches">
+                                    Tissot Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-47">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-watches">
+                                    Victorinox Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-113">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rolex-watches">
+                                    Rolex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-327">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sevenfriday-watches">
+                                    SevenFriday Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-337">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/franck-muller-watches">
+                                    Franck Muller Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-848">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/gc-watches">
+                                    Gc Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-137 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fashion-brands">
+                                    Fashion Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-116">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/armani-exchange-watches">
+                                    Armani Exchange Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-355">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/hugo-boss-watches">
+                                    Hugo Boss Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calvin-klein-watches">
+                                    Calvin Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-18">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/diesel-watches">
+                                    Diesel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-915">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tornado-watches">
+                                    Tornado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-918">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/aston-martin-watches">
+                                    Aston Martin Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-920">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/off-road-watches">
+                                    Off Road Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/emporio-armani-watches">
+                                    Emporio Armani Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-913">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rock-revival-watches">
+                                    Rock Revival Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-917">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jean-fendi-watches">
+                                    Jean Fendi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-910">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/foce-watches">
+                                    Foce Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-32">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/esprit-watches">
+                                    Esprit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-148">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/giordano-watches">
+                                    Giordano Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-183">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-watches">
+                                    Kenneth Cole Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-149">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/michael-kors-watches">
+                                    Michael Kors Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-23">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/police-watches">
+                                    Police Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-107">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skagen-watches">
+                                    Skagen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-35">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/swatch-watches">
+                                    Swatch Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-24">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tommy-hilfiger-watches">
+                                    Tommy Hilfiger Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-256">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-watches">
+                                    Fossil Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-101">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/alba-watches">
+                                    Alba Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-262">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/obaku-watches">
+                                    Obaku Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-323">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/anne-klein-watches">
+                                    Anne Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-324">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/earnshaw-watches">
+                                    Earnshaw Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-326">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/strand-watches">
+                                    Strand Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-342">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/coach-watches">
+                                    Coach Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-351">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/guess-watches">
+                                    Guess Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-353">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/daniel-wellington-watches">
+                                    Daniel Wellington Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-22">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/citizen-watches">
+                                    Citizen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-850">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/quantum-watches">
+                                    Quantum Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-903">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/cerruti-watches">
+                                    Cerruti Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-142 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessible-desirable-brands">
+                                    Accessible & Desirable Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-watches">
+                                    Fastrack Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/qnq-watches">
+                                    Q&Q Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-64">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sonata-watches">
+                                    Sonata Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-318">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/horo-watches">
+                                    Horo Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-852">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tickid-watches">
+                                    Tickid Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-27">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/timex-watches">
+                                    Timex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-122">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/westar-watches">
+                                    Westar Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zoop-watches">
+                                    Zoop Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-119">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/helix-watches">
+                                    Helix Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-41 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-watches">
+                                    Casio Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-247">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sheen-watches">
+                                    Sheen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-248">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/baby-g-watches">
+                                    Baby-G Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-250">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/youth-watches">
+                                    Youth Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-252">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/outdoor-watches">
+                                    Outdoor Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-266">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/enticer-watches">
+                                    Enticer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-253">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watches">
+                                    Smart Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-267">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/protrek-watches">
+                                    Protrek Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-268">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/vintage-watches">
+                                    Vintage Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-281">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/g-shock-watches">
+                                    G-Shock Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-282">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/edifice-watches">
+                                    Edifice Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-26">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-watches">
+                                    Titan Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-904">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-watches">
+                                    Jack & Jill Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-842 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watch-brands">
+                                    Smart Watch Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-320">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/firebolt-watches">
+                                    Firebolt Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-302">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-watches">
+                                    Mi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-315">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/beetel-watches">
+                                    Beetel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-341">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/techlog-watches">
+                                    TechLog Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-345">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/boat-watches">
+                                    Boat Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-348">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/amazfit-watches">
+                                    Amazfit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-845">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/just-corseca-watches">
+                                    Just Corseca Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-151 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/stopwatches">
+                                    Stopwatches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-283">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-stopwatches">
+                                    Casio Stopwatches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-187 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessories">
+                                    Accessories                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-194 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/belts">
+                                    Belts                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-851">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-belts">
+                                    Titan Belts                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-844">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-belts">
+                                    Fossil Belts                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-199 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/wallets">
+                                    Wallets                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-908">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-wallets">
+                                    Titan Wallets                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-356">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-wallets">
+                                    Fossil Wallets                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-310 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sunglasses">
+                                    Sunglasses                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-311">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-sunglasses">
+                                    Fastrack Sunglasses                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-312">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-sunglasses">
+                                    Mi Sunglasses                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-919">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-sunglasses">
+                                    Jack & Jill Sunglasses                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-316">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-accessories">
+                                    Fastrack Accessories                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-856">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-bags">
+                                    Fastrack Bags                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-907">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-knifes">
+                                    Victorinox Knifes                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-321 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/perfumes">
+                                    Perfumes                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-322">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skin-perfumes">
+                                    Skin Perfumes                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-330">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-accessories">
+                                    Kenneth Cole Accessories                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-862">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zippo-lighters">
+                                    Zippo Lighters                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-911">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/paul-design-watch-winders">
+                                    Paul Design Watch Winders                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-258 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/electronics">
+                                    Electronics                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-260 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calculators">
+                                    Calculators                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-160">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-calculator">
+                                    Casio Calculator                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-top-deals-offers">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/prices-drop">
+                                    Top Deals & Offers                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-instagram-store">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/instagram-store">
+                                    Instagram Store                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-141">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/our-stores">
+                                    Our Stores                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-140">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/about-us">
+                                    About us                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-138">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/careers">
+                                    Careers                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-my-account">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/login?back=my-account">
+                                    My Account                                </a>
+                            </li>
+        		
+        <li class="rolex_menu">
+          <div>
+          <a href="https://www.swisstimehouse.com/content/rolex" style="display: block;padding: 5px 0px;">
+            <span style="display: inline-block;    position: relative;
+    width: 150px;
+    height: 70px;" class="rolex-retailer-clock mob_rolex"></span>
+          </a>
+          </div>
+
+        </li>
+              </ul>
+        </nav>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-7a50bef9 ce-valign-center elementor-hidden-phone elementor-column elementor-col-25 elementor-top-column" data-id="7a50bef9" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-42ff9e82 elementor-widget__width-auto elementor-widget elementor-widget-ps-widget-module" data-id="42ff9e82" data-element_type="widget" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- iqitmegamenu -->
+	<div id="iqitmegamenu-wrapper" class="iqitmegamenu-wrapper iqitmegamenu-all">
+		<div class="container container-iqitmegamenu">
+		<div id="iqitmegamenu-horizontal" class="iqitmegamenu  clearfix" role="navigation">
+
+								
+				<nav id="cbp-hrmenu" class="cbp-hrmenu cbp-horizontal cbp-hrsub-narrow">
+					<ul>
+												<li id="cbp-hrmenu-tab-45" class="cbp-hrmenu-tab cbp-hrmenu-tab-45  cbp-has-submeu">
+	<a role="button" class="cbp-empty-mlink nav-link">
+
+								<span class="cbp-tab-title"> <i class="icon fa fa-bars cbp-mainlink-icon"></i>
+								MENU <i class="fa fa-align-justify cbp-submenu-aindicator"></i></span>
+														</a>
+														<div class="cbp-hrsub col-12">
+								<div class="cbp-hrsub-inner">
+								<div class="logo-container">
+                                                                          <img
+                                                                                            src="https://www.swisstimehouse.com/img/swiss-time-house-logo-1665736482.jpg"
+                                                width="350"
+                                                height="51"
+                                                                                        class="logo img-fluid"
+                                            alt="Swiss Time House logo">
+                                                                    </div>
+									<div class="close_megamenu"> <i class="ceicon-close"></i></div>
+									<div class="container iqitmegamenu-submenu-container">
+																		<div class="cbp-tabs-container">
+									<div class="row no-gutters">
+									<div class="tabs-links col-2">
+										<ul class="cbp-hrsub-tabs-names cbp-tabs-names" >
+																																	<li class="innertab-32 ">
+												<a data-target="#iq-32-innertab-45"  href="https://www.swisstimehouse.com/watches"  class="nav-link active">
+												 <i class="icon fa fa-clock-o cbp-mainlink-icon"></i>																								Watches 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-28 ">
+												<a data-target="#iq-28-innertab-45"  href="https://www.swisstimehouse.com/watches"  class="nav-link ">
+																																				Find Your Watch 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-39 ">
+												<a data-target="#iq-39-innertab-45"  href="https://www.swisstimehouse.com/prices-drop"  class="nav-link ">
+												 <i class="icon fa fa-bullhorn cbp-mainlink-icon"></i>																								Top Deals &amp; Offers 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-29 ">
+												<a data-target="#iq-29-innertab-45"  href="https://www.swisstimehouse.com/clocks"  class="nav-link ">
+																																				Clocks 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-30 ">
+												<a data-target="#iq-30-innertab-45"  href="https://www.swisstimehouse.com/accessories"  class="nav-link ">
+																																				Accessories 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-33 ">
+												<a data-target="#iq-33-innertab-45"  href="https://www.swisstimehouse.com/about-us"  class="nav-link ">
+																																				About us 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-34 ">
+												<a data-target="#iq-34-innertab-45"  href="https://www.swisstimehouse.com/our-stores"  class="nav-link ">
+												 <i class="icon fa fa-home cbp-mainlink-icon"></i>																								Our Stores 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																						<li class="innertab-40 ">
+												<a data-target="#iq-40-innertab-45"  href="https://www.swisstimehouse.com/"  class="nav-link ">
+												 <i class="icon fa fa-backward cbp-mainlink-icon"></i>																								Back to Homepage 																									<i class="fa fa-angle-right cbp-submenu-it-indicator"></i></a><span class="cbp-inner-border-hider"></span></li>
+																																</ul>
+									</div>
+
+																				<div class="tab-content col-10">
+																						<div class="tab-pane cbp-tab-pane active innertabcontent-32"
+												 id="iq-32-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-2 cbp-menu-column cbp-menu-element menu-element-id-18 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                                    <ul class="cbp-manufacturers row">
+                                                                                                                <li class="col-12 transition-opacity-300">
+                                    <a href="https://www.swisstimehouse.com/manufacturer/rado"
+                                       title="Manufacturer - Rado">
+                                        <img src="https://www.swisstimehouse.com/img/m/2-small_default.jpg"
+                                             class="img-fluid logo_manufacturer "  width="98" height="127"                                             alt="Manufacturer - Rado"/>
+                                    </a>
+                                </li>
+                                                                                                                                            <li class="col-12 transition-opacity-300">
+                                    <a href="https://www.swisstimehouse.com/manufacturer/rock-revival"
+                                       title="Manufacturer - Rock Revival">
+                                        <img src="https://www.swisstimehouse.com/img/m/214-small_default.jpg"
+                                             class="img-fluid logo_manufacturer "  width="98" height="127"                                             alt="Manufacturer - Rock Revival"/>
+                                    </a>
+                                </li>
+                                                                        </ul>
+                
+            
+
+                                                
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-19">
+                
+
+                                                
+
+
+
+
+    <div class="col-12 cbp-menu-column cbp-menu-element menu-element-id-20 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                                    <ul class="cbp-manufacturers row">
+                                                                                                                <li class="col-12 transition-opacity-300">
+                                    <a href="https://www.swisstimehouse.com/manufacturer/casio"
+                                       title="Manufacturer - Casio">
+                                        <img src="https://www.swisstimehouse.com/img/m/21-small_default.jpg"
+                                             class="img-fluid logo_manufacturer "  width="98" height="127"                                             alt="Manufacturer - Casio"/>
+                                    </a>
+                                </li>
+                                                                                                                                            <li class="col-12 transition-opacity-300">
+                                    <a href="https://www.swisstimehouse.com/manufacturer/longines"
+                                       title="Manufacturer - Longines">
+                                        <img src="https://www.swisstimehouse.com/img/m/40-small_default.jpg"
+                                             class="img-fluid logo_manufacturer "  width="98" height="127"                                             alt="Manufacturer - Longines"/>
+                                    </a>
+                                </li>
+                                                                        </ul>
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+                            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-10 cbp-menu-column cbp-menu-element menu-element-id-2 cbp-empty-column">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <a href="https://www.swisstimehouse.com/manufacturers"
+                           class="cbp-column-title nav-link">OUR BRANDS </a>
+                                    
+                
+            
+
+                                                
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-6">
+                
+
+                                                
+
+
+
+
+    <div class="col-2 cbp-menu-column cbp-menu-element menu-element-id-7 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">A - E </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/alba" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Alba</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/aston-martin-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Aston Martin</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/anne-klein" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Anne Klein</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/armani-exchange" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Armani Exchange<br /></a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/balmain" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Balmain</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" style="box-sizing: border-box; border-style: none; vertical-align: middle; height: auto; font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 11px; white-space: normal; background-color: #fafbfc;" width="13.5" height="13.5" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/beetel" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Beetel</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/boat" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Boat</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/calvin-klein" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Calvin Klein</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" style="box-sizing: border-box; border-style: none; vertical-align: middle; height: auto; font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 11px; white-space: normal; background-color: #fafbfc;" width="13.5" height="13.5" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/casio" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Casio</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/cerruti" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Cerruti</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/citizen" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Citizen</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/coach" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Coach</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/daniel-wellington" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Daniel Wellington</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/diesel" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Diesel</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/earnshaw" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Earnshaw</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/emporio-armani" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Emporio Armani</a></li>
+</ul>
+</ul>
+<p></p>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-3 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">E - N </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/fastrack" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Fastrack</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/firebolt" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Firebolt</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/foce" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Foce</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/fossil" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Fossil</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/franck-muller" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Franck Muller</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/gc" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">GC</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/guess" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Guess</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/helix" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Helix</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/hugo-boss" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Hugo Boss</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/horo" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Horo</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/jack-jill" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Jack &amp; Jill</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/jean-fendi" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Jean Fendi</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/kenneth-cole" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Kenneth Cole</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/longines" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Longines</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/michael-kors" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Michael Kors</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/movado" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Movado</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-2 cbp-menu-column cbp-menu-element menu-element-id-4 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">O - S </span>
+                                    
+                
+                                             <p></p>
+<ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/omega" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Omega</a>  <img src="https://www.swisstimehouse.com/img/cms/site april 2020/download (1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/police" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Police</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/qq" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Q&amp;Q</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/quantum" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Quantum</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/rock-revival" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rock Revival</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/rado" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rado</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/rhythm" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rhythm</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/seiko" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Seiko</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/sevenfriday" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">SevenFriday</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/skagen" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Skagen</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/sonata" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Sonata</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/swatch" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Swatch</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-2 cbp-menu-column cbp-menu-element menu-element-id-5 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">T - Z </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/tag-heuer" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Tag Heuer</a>  <img src="https://www.swisstimehouse.com/img/cms/site april 2020/download (1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/timex" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Timex</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/tissot" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Tissot</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/titan" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Titan</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/tommy-hilfiger" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Tommy Hilfiger</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/tornado" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Tornado</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/victorinox" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Victorinox</a>  <img src="https://www.swisstimehouse.com/img/cms/site%20april%202020/download%20(1)1.png" alt="" width="13.5" height="14" /></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/manufacturer/zoop" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Zoop</a></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-10 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/tissot-watches">                        <img src="/img/cms/25 may/menu_watches banner.jpg" class="img-fluid cbp-banner-image"
+                                                              width="260" height="500" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+                            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-28"
+												 id="iq-28-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-2 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                    
+                                                    <div class="row cbp-categories-row">
+                                                                                                            <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/watches"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Watches</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/luxury-brands">Luxury &amp; Premium Brands</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/fashion-brands">Fashion Brands</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/accessible-desirable-brands">Accessible &amp; Desirable Brands</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/smart-watch-brands">Smart Watch Brands</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                </div>
+                                            
+                
+            
+
+                                                
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-6">
+                
+
+                                                
+
+
+
+
+    <div class="col-12 cbp-menu-column cbp-menu-element menu-element-id-8 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">Shop by Gender </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/mens-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Men</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/womens-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Women</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/kids-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Kids</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/couple-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Couple Watches</a></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-12 cbp-menu-column cbp-menu-element menu-element-id-10 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/prices-drop?products=watches">                        <img src="/img/cms/site april 2020/SALE-500X70px (1).jpg" class="img-fluid cbp-banner-image"
+                                                              width="500" height="70" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-12 cbp-menu-column cbp-menu-element menu-element-id-11 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/new-products?products=watches">                        <img src="/img/cms/site april 2020/NEW-ARRIVALS-500X70px (1).jpg" class="img-fluid cbp-banner-image"
+                                                              width="500" height="70" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+                            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-3 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">Shop by Price </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-under-5000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Below Rs. 5,000</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-5000-10000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 5,000 to Rs. 10,000</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-10000-20000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 10,000 to Rs. 20,000</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-20000-30000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 20,000 to Rs. 30,000</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-30000-50000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 30,000 to Rs. 50,000</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-50000-100000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 50,000 to Rs. 1 Lakh</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-100000-200000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 1 Lakh to Rs. 2 Lakh</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-200000-300000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 2 Lakh to Rs. 3 Lakh</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-from-300000-500000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rs. 3 Lakh to Rs. 5 Lakh</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches-above-500000" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Above Rs. 5 Lakh</a></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-4 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">Shop by Features </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/smart-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Smart Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/movement-automatic" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Automatic Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/movement-quartz" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Quartz Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-material-leather" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Leather Strap Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-color-rose-gold" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Rose Gold Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-color-gold" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Gold Plated Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-material-metal-steel" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Steel Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-color-black" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Black Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/band-color-two-tone" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Two Tone Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/case-ceramic" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Ceramic Watches</a></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-12 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">- </span>
+                                    
+                
+                                             <ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 13px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/case-titanium" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Titanium Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/glass-sapphire-crystal" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Sapphire Crystal Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-alarm" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Alarm Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-altimeter" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Altimeter Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-chronograph" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Chronograph Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-compass" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Compass Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-date" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Date Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-day-date" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Day-Date Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches/features-dual-time" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">Dual Time Watches</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #000000 !important;">World Time Watches</a></li>
+</ul>
+                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-39"
+												 id="iq-39-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-5 cbp-menu-column cbp-menu-element menu-element-id-2 cbp-empty-column">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+            
+
+                                                
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-9">
+                
+
+                                                
+
+
+
+
+    <div class="col-6 cbp-menu-column cbp-menu-element menu-element-id-15 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/prices-drop?gender=men">                        <img src="/img/cms/24May/casio/mens upto50 OFF.jpg" class="img-fluid cbp-banner-image"
+                                                              width="520" height="1000" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-6 cbp-menu-column cbp-menu-element menu-element-id-14 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/prices-drop?gender=women">                        <img src="/img/cms/24May/casio/womens upto50 OFF.jpg" class="img-fluid cbp-banner-image"
+                                                              width="520" height="1000" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+                                    
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-13">
+                
+
+            
+                </div>
+                            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-7 cbp-menu-column cbp-menu-element menu-element-id-10 ">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <a href="https://www.swisstimehouse.com/prices-drop"
+                           class="cbp-column-title nav-link">&gt; Shop Now </a>
+                                    
+                
+                                                                        
+<div class="cbp-products-big row ">
+            <div class="product-grid-menu col-4">
+            <div class="product-container">
+                <div class="product-image-container">
+                    <ul class="product-flags">
+                                                    <li class="product-flag discount">-50%</li>
+                                                    <li class="product-flag out_of_stock">Sold Out</li>
+                                            </ul>
+                    <a class="product_img_link" href="https://www.swisstimehouse.com/earnshaw-es-8129-44-mens-watch" title="ES-8129-44">
+                        <img class="img-fluid"
+                             src="https://www.swisstimehouse.com/121561-home_default/earnshaw-es-8129-44-mens-watch.jpg"
+                             alt="ES-8129-44"
+                             width="440" height="569" />
+                    </a>
+                </div>
+                <h6 class="product-title">
+                    <a href="https://www.swisstimehouse.com/earnshaw-es-8129-44-mens-watch">ES-8129-44</a>
+                </h6>
+                <div class="product-price-and-shipping" >
+                    <span class="product-price">₹ 29,975</span>
+                                            
+                        <span class="regular-price text-muted">₹ 59,950</span>
+                                    </div>
+            </div>
+        </div>
+    </div>
+                                            
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-7">
+                
+
+            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-29"
+												 id="iq-29-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-4 cbp-menu-column cbp-menu-element menu-element-id-2 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                    
+                                                    <div class="row cbp-categories-row">
+                                                                                                            <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/wall-clocks"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Wall Clocks</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/rhythm-clocks">Rhythm Clocks</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/seiko-clocks">Seiko Clocks</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/casio-clocks">Casio Clocks</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/opal-clocks">Opal Clocks</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/x-hour-clocks">X-Hour Clocks</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                                                                <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/grand-father-clocks"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Grand Father Clocks</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/d-time-grand-father-clocks">D Time Grand Father Clocks</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/mq-grand-father-clocks">Mq Grand Father Clocks</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                </div>
+                                            
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-6 cbp-menu-column cbp-menu-element menu-element-id-3 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/clocks">                        <img src="/img/cms/24May/casio/clock banner.jpg" class="img-fluid cbp-banner-image"
+                                                              width="780" height="350" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-30"
+												 id="iq-30-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-4 cbp-menu-column cbp-menu-element menu-element-id-2 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                    
+                                                    <div class="row cbp-categories-row">
+                                                                                                            <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/belts"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Belts</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/titan-belts">Titan Belts</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/fossil-belts">Fossil Belts</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                                                                <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/wallets"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Wallets</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/titan-wallets">Titan Wallets</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/fossil-wallets">Fossil Wallets</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                                                                <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/sunglasses"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Sunglasses</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/fastrack-sunglasses">Fastrack Sunglasses</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/mi-sunglasses">Mi Sunglasses</a></div></li><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/jack-jill-sunglasses">Jack &amp; Jill Sunglasses</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                                                                <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/fastrack-accessories"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Fastrack Accessories</a>
+                                                                                                                                            </div>
+                                        </div>
+                                                                                                </div>
+                                            
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-4 cbp-menu-column cbp-menu-element menu-element-id-5 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                    
+                                                    <div class="row cbp-categories-row">
+                                                                                                            <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/perfumes"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Perfumes</a>
+                                                                                                                                                    
+    <ul class="cbp-links cbp-category-tree"><li ><div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/skin-perfumes">Skin Perfumes</a></div></li></ul>
+
+                                                                                            </div>
+                                        </div>
+                                                                                                                                                <div class="col-12">
+                                            <div class="cbp-category-link-w"><a href="https://www.swisstimehouse.com/kenneth-cole-accessories"
+                                                                                class="cbp-column-title nav-link cbp-category-title">Kenneth Cole Accessories</a>
+                                                                                                                                            </div>
+                                        </div>
+                                                                                                </div>
+                                            
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-4 cbp-menu-column cbp-menu-element menu-element-id-8 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/accessories">                        <img src="/img/cms/22 april/ACCESSORIES 1-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="780" height="350" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-33"
+												 id="iq-33-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-4 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                             <h2><span style="color: #c60404;"><strong>SWISS GROUP</strong></span> </h2>
+<hr />
+<p> </p>
+<ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 15px; white-space: nowrap; background-color: #ffffff;">
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/about-us" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; padding-bottom: 10px; display: inline-block; color: #000000 !important;">About Us</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/1946" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; padding-bottom: 10px; display: inline-block; color: #000000 !important;">1946 - The Concept</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/our-stores" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; padding-bottom: 10px; display: inline-block; color: #000000 !important;">Our Stores</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/careers" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; padding-bottom: 10px; display: inline-block; color: #000000 !important;">Careers</a></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li>
+<li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/contact-us" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; padding-bottom: 10px; display: inline-block; color: #000000 !important;">Contact Us</a></li>
+</ul>
+<p></p>
+                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-9 cbp-menu-column cbp-menu-element menu-element-id-5 cbp-empty-column">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+            
+
+                                                
+
+
+
+
+<div class="row menu_row menu-element  menu-element-id-6">
+                
+
+                                                
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-7 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/about-us">                        <img src="/img/cms/22 april/about us-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="260" height="500" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-8 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/contact-us">                        <img src="/img/cms/22 april/contact us-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="260" height="500" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-9 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores">                        <img src="/img/cms/25 may/60+ stores banner.jpg" class="img-fluid cbp-banner-image"
+                                                              width="260" height="500" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-10 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/careers">                        <img src="/img/cms/22 april/4join our team-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="260" height="500" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+                            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-34"
+												 id="iq-34-innertab-45" role="tabpanel">
+
+																								<div class="clearfix">
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-11">
+                
+
+                                                
+
+
+
+
+    <div class="col-12 cbp-menu-column cbp-menu-element menu-element-id-12 cbp-empty-column">
+        <div class="cbp-menu-column-inner">
+                        
+                                                            <span class="cbp-column-title nav-link transition-300">50 Stores and Counting </span>
+                                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-1">
+                
+
+                                                
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-2 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores">                        <img src="/img/cms/22 april/swb_1-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="800" height="533" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-3 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#SwissTimeHouse">                        <img src="/img/cms/Stores/3_1.jpg" class="img-fluid cbp-banner-image"
+                                                              width="800" height="533" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-4 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#1946">                        <img src="/img/cms/Stores/13_2.jpg" class="img-fluid cbp-banner-image"
+                                                              width="800" height="533" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-5 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#ExclusiveBoutiques">                        <img src="/img/cms/22 Jan/rado kochi-min.jpg" class="img-fluid cbp-banner-image"
+                                                              width="800" height="533" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																									
+
+
+
+
+<div class="row menu_row menu-element  first_rows menu-element-id-6">
+                
+
+                                                
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-7 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores">                        <img src="/img/cms/Swiss-botique-logo png.png" class="img-fluid cbp-banner-image"
+                                                              width="398" height="230" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-8 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#SwissTimeHouse">                        <img src="/img/cms/21 oct/swiss-time-house-logo 796x460.png" class="img-fluid cbp-banner-image"
+                                                              width="796" height="460" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-9 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#1946">                        <img src="/img/cms/24May/icon/1946 Logo.png" class="img-fluid cbp-banner-image"
+                                                              width="398" height="230" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                                    
+
+
+
+
+    <div class="col-3 cbp-menu-column cbp-menu-element menu-element-id-10 ">
+        <div class="cbp-menu-column-inner">
+                        
+                
+                
+                                            <a href="https://www.swisstimehouse.com/our-stores#ExclusiveBoutiques">                        <img src="/img/cms/site april 2020/exclusive-boutiques.png" class="img-fluid cbp-banner-image"
+                                                              width="352" height="176" />
+                        </a>                    
+                
+            
+
+            
+            </div>    </div>
+                            
+                </div>
+																								</div>
+												
+											</div>
+																						<div class="tab-pane cbp-tab-pane  innertabcontent-40"
+												 id="iq-40-innertab-45" role="tabpanel">
+
+												
+											</div>
+																					</div>
+										
+									</div></div>
+																			</div>
+								</div>
+							</div>
+													</li>
+											</ul>
+				</nav>
+		</div>
+		</div>
+		<!-- <div id="sticky-cart-wrapper"></div> -->
+	</div>
+
+<div id="_desktop_iqitmegamenu-mobile">
+	<ul id="iqitmegamenu-mobile">
+		
+
+
+
+	
+	<li><a href="https://www.swisstimehouse.com/">Home</a></li><li><span class="mm-expand"><i class="fa fa-angle-down expand-icon" aria-hidden="true"></i><i class="fa fa-angle-up close-icon" aria-hidden="true"></i></span><a href="https://www.swisstimehouse.com/watches">Watches</a>
+	<ul><li><a href="https://www.swisstimehouse.com/luxury-brands">Luxury &amp; Premium Brands</a></li><li><a href="https://www.swisstimehouse.com/fashion-brands">Fashion Brands</a></li><li><a href="https://www.swisstimehouse.com/accessible-desirable-brands">Accessible &amp; Desirable Brands</a></li><li><a href="https://www.swisstimehouse.com/smart-watch-brands">Smart Watch Brands</a></li></ul></li><li><a href="https://www.swisstimehouse.com/manufacturers">Our Brands</a></li><li><span class="mm-expand"><i class="fa fa-angle-down expand-icon" aria-hidden="true"></i><i class="fa fa-angle-up close-icon" aria-hidden="true"></i></span><a href="https://www.swisstimehouse.com/products">Products</a>
+	<ul><li><a href="https://www.swisstimehouse.com/clocks">Clocks</a></li><li><a href="https://www.swisstimehouse.com/watches">Watches</a></li><li><a href="https://www.swisstimehouse.com/stopwatches">Stopwatches</a></li><li><a href="https://www.swisstimehouse.com/accessories">Accessories</a></li><li><a href="https://www.swisstimehouse.com/electronics">Electronics</a></li></ul></li><li><a href="https://www.swisstimehouse.com/prices-drop">Top Deals &amp; Offers</a></li><li><a href="https://www.swisstimehouse.com/">Back to Homepage</a></li>
+	</ul>
+</div>
+</div>        </div>
+                <div class="elementor-element elementor-element-77c72d3f elementor-widget__width-auto elementor-widget elementor-widget-heading" data-id="77c72d3f" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/product-catalogue/mens-watches">MEN</a></h2></div>        </div>
+                <div class="elementor-element elementor-element-12955a19 elementor-widget__width-auto elementor-widget elementor-widget-heading" data-id="12955a19" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/product-catalogue/womens-watches">WOMEN</a></h2></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-7dd5dd13 elementor-column elementor-col-25 elementor-top-column" data-id="7dd5dd13" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-57899eb2 elementor-widget-mobile__width-initial elementor-widget elementor-widget-theme-site-logo elementor-widget-image" data-id="57899eb2" data-element_type="widget" data-widget_type="theme-site-logo.default">
+        <div class="elementor-widget-container"><a href="https://www.swisstimehouse.com/"><img src="/img/swiss-time-house-logo-1665736482.jpg" alt="Swiss Time House" width="350" height="51"></a></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-38ab8538 elementor-hidden-phone elementor-column elementor-col-25 elementor-top-column" data-id="38ab8538" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-23703b84 elementor-search--skin-minimal elementor-widget__width-auto header-search-typing elementor-widget elementor-widget-ajax-search" data-id="23703b84" data-element_type="widget" data-settings="{&quot;skin&quot;:&quot;minimal&quot;,&quot;list_limit&quot;:10,&quot;show_image&quot;:&quot;yes&quot;,&quot;show_category&quot;:&quot;yes&quot;,&quot;show_price&quot;:&quot;yes&quot;}" data-widget_type="ajax-search.default">
+        <div class="elementor-widget-container">        <form class="elementor-search" role="search" action="https://www.swisstimehouse.com/search" method="get">
+                            <div class="elementor-search__container">
+                            <div class="elementor-search__icon" aria-label="Search">
+                    <i aria-hidden="true" class="ceicon ceicon-search-glint"></i>                </div>
+                            <input class="elementor-search__input" type="search" name="s" placeholder="Search our catalog" value="" minlength="2" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list">
+                            <div class="elementor-search__icon elementor-search__clear" aria-hidden="true"><i class="ceicon-close"></i></div>
+                                    </div>
+        </form>
+        </div>        </div>
+                <div class="elementor-element elementor-element-7e209d48 elementor-cart--items-indicator-none elementor-widget__width-auto elementor-cart--show-subtotal-yes elementor-cart--align-icon-left elementor-cart--show-shipping-yes elementor-cart--show-view-cart-yes elementor-cart--show-checkout-yes elementor-cart--buttons-inline elementor-widget elementor-widget-shopping-cart" data-id="7e209d48" data-element_type="widget" data-settings="{&quot;modal_url&quot;:&quot;https:\/\/www.swisstimehouse.com\/module\/creativeelements\/ajax&quot;,&quot;labels&quot;:{&quot;gift&quot;:&quot;Gift&quot;,&quot;facetLabelFacetValue&quot;:&quot;%facet_label%: %facet_value%&quot;,&quot;productDetails&quot;:&quot;Product Details&quot;,&quot;regularPrice&quot;:&quot;Regular price&quot;,&quot;removeFromCart&quot;:&quot;remove from cart&quot;},&quot;action_open_cart&quot;:&quot;yes&quot;,&quot;action_show_modal&quot;:&quot;yes&quot;,&quot;remove_item_icon&quot;:{&quot;value&quot;:&quot;far fa-circle-xmark&quot;,&quot;library&quot;:&quot;fa-regular&quot;}}" data-widget_type="shopping-cart.default">
+        <div class="elementor-widget-container">            <dialog class="elementor-cart__container elementor-lightbox" id="elementor-cart__dialog-7e209d48" aria-modal="true" aria-labelledby="elementor-cart__title-7e209d48">
+                <div class="elementor-cart__main">
+                    <a class="elementor-cart__close-button ceicon-close" href="javascript://close" role="button" aria-label="Close"></a>
+                    <div class="elementor-cart__title" id="elementor-cart__title-7e209d48">
+                        Your Shopping Cart                    </div>
+                            <div class="elementor-cart__empty-message" role="alert" aria-live="polite">No products in the cart.</div>
+        <div class="elementor-cart__products ce-scrollbar-y--auto" role="list">
+                    </div>
+        <div class="elementor-cart__summary" role="list" aria-label="Your order">
+            <div class="elementor-cart__summary-label" role="term">0 items</div>
+            <div class="elementor-cart__summary-value" role="definition">₹ 0</div>
+                    <span class="elementor-cart__summary-label" role="term">Shipping</span>
+            <span class="elementor-cart__summary-value" role="definition"></span>
+            <strong class="elementor-cart__summary-label" role="term">Total</strong>
+            <strong class="elementor-cart__summary-value" role="definition">₹ 0</strong>
+        </div>
+        <div class="elementor-alert elementor-alert-warning" hidden role="alert" aria-live="polite">
+            <span class="elementor-alert-description"></span>
+        </div>
+        <footer class="elementor-cart__footer-buttons">
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-button--cart elementor-size-md">
+                    <span class="elementor-button-text">View Cart</span>
+                </a>
+            </div>
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/order" class="elementor-button elementor-button--checkout elementor-size-md"tabindex="-1" aria-disabled="true">
+                    <span class="elementor-button-text">Checkout</span>
+                </a>
+            </div>
+        </footer>
+        <!--<div class="snap_emi_txt"></div>
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="0" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="checkout_page"></span>
+	  --->                </div>
+            </dialog>        <div class="elementor-cart__toggle">
+            <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-size-sm" role="button" aria-label="Shopping Cart" aria-controls="elementor-cart__dialog-7e209d48" aria-expanded="false" aria-description="₹ 0">
+                <span class="elementor-button-icon" data-counter="0" aria-hidden="true">
+                    <i class="ceicon ceicon-cart-medium"></i>                </span>
+                <span class="elementor-button-text">₹ 0</span>
+            </a>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-7a0468f2 elementor-section-full_width elementor-hidden-tablet elementor-hidden-phone elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="7a0468f2" data-element_type="section" data-settings="{&quot;sticky&quot;:&quot;bottom&quot;,&quot;sticky_offset&quot;:130,&quot;sticky_effects_offset&quot;:2,&quot;sticky_on&quot;:[&quot;desktop&quot;,&quot;tablet&quot;,&quot;mobile&quot;]}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-61fde038 elementor-column elementor-col-50 elementor-top-column" data-id="61fde038" data-element_type="column">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-2f31465a desktop-custom-menu ce-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="2f31465a" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-412e9bb6 elementor-view-default elementor-widget elementor-widget-icon" data-id="412e9bb6" data-element_type="widget" data-widget_type="icon.default">
+        <div class="elementor-widget-container">        <a class="elementor-icon" href="https://www.swisstimehouse.com/">
+            <i aria-hidden="true" class="fas fa-house-chimney"></i>        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-4a95fb60 elementor-widget elementor-widget-html" data-id="4a95fb60" data-element_type="widget" data-widget_type="html.default">
+        <div class="elementor-widget-container"><span style="display: block; text-align: center; font-size: 18px;" class="cbp-tab-title-custom">
+    <i class="fa fa-navicon"></i>
+</span>
+</div>        </div>
+                <div class="elementor-element elementor-element-6eafd879 otp_login elementor-nav--align-center elementor-widget elementor-widget-sign-in elementor-widget-nav-menu" data-id="6eafd879" data-element_type="widget" data-settings="{&quot;align_submenu&quot;:&quot;right&quot;,&quot;submenu_icon&quot;:{&quot;value&quot;:&quot;&quot;,&quot;library&quot;:&quot;&quot;},&quot;show_submenu_on&quot;:&quot;click&quot;,&quot;layout&quot;:&quot;horizontal&quot;}" data-widget_type="sign-in.default">
+        <div class="elementor-widget-container">        <nav class="ce-user-menu elementor-nav--main elementor-nav__container elementor-nav--layout-horizontal" aria-label="User Menu">        <ul class="elementor-nav" id="usermenu-6eafd879" role="none">
+                    <li class="menu-item menu-item-type-account menu-item-account-0">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/my-account" aria-label="My account">
+                    <i class="ceicon ceicon-user-o"></i>                                                </a>
+                            </li>
+                </ul>
+        </nav>
+        </div>        </div>
+                <div class="elementor-element elementor-element-ad59e47 elementor-search--skin-topbar elementor-widget elementor-widget-ajax-search" data-id="ad59e47" data-element_type="widget" data-settings="{&quot;skin&quot;:&quot;topbar&quot;,&quot;list_limit&quot;:10,&quot;show_image&quot;:&quot;yes&quot;,&quot;show_category&quot;:&quot;yes&quot;,&quot;show_price&quot;:&quot;yes&quot;}" data-widget_type="ajax-search.default">
+        <div class="elementor-widget-container">        <form class="elementor-search" role="search" action="https://www.swisstimehouse.com/search" method="get">
+                            <div class="elementor-search__toggle" role="button" tabindex="0" aria-label="Search" aria-controls="elementor-search__container-ad59e47" aria-expanded="false">
+                <i aria-hidden="true" class="ceicon ceicon-search-glint"></i>            </div>
+                    <div class="elementor-search__container" id="elementor-search__container-ad59e47" role="dialog" aria-labelledby="elementor-search__label-ad59e47">
+                            <div class="elementor-search__label" id="elementor-search__label-ad59e47">What are you looking for?</div>
+                <div class="elementor-search__input-wrapper">
+                            <input class="elementor-search__input" type="search" name="s" placeholder="Search our catalog" value="" minlength="2" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list">
+                            <div class="elementor-search__icon elementor-search__clear" aria-hidden="true"><i class="ceicon-close"></i></div>
+                                        </div>
+                <div class="dialog-lightbox-close-button" role="button" tabindex="0" aria-label="Close">
+                    <i class="ceicon-close" aria-hidden="true"></i>
+                </div>
+                        </div>
+        </form>
+        </div>        </div>
+                <div class="elementor-element elementor-element-4f2fbc29 elementor-cart--empty-indicator-hide elementor-cart--items-indicator-bubble elementor-cart--show-shipping-yes elementor-cart--show-view-cart-yes elementor-cart--show-checkout-yes elementor-cart--buttons-inline elementor-widget elementor-widget-shopping-cart" data-id="4f2fbc29" data-element_type="widget" data-settings="{&quot;modal_url&quot;:&quot;https:\/\/www.swisstimehouse.com\/module\/creativeelements\/ajax&quot;,&quot;labels&quot;:{&quot;gift&quot;:&quot;Gift&quot;,&quot;facetLabelFacetValue&quot;:&quot;%facet_label%: %facet_value%&quot;,&quot;productDetails&quot;:&quot;Product Details&quot;,&quot;regularPrice&quot;:&quot;Regular price&quot;,&quot;removeFromCart&quot;:&quot;remove from cart&quot;},&quot;action_open_cart&quot;:&quot;yes&quot;,&quot;action_show_modal&quot;:&quot;yes&quot;,&quot;remove_item_icon&quot;:{&quot;value&quot;:&quot;far fa-circle-xmark&quot;,&quot;library&quot;:&quot;fa-regular&quot;}}" data-widget_type="shopping-cart.default">
+        <div class="elementor-widget-container">            <dialog class="elementor-cart__container elementor-lightbox" id="elementor-cart__dialog-4f2fbc29" aria-modal="true" aria-labelledby="elementor-cart__title-4f2fbc29">
+                <div class="elementor-cart__main">
+                    <a class="elementor-cart__close-button ceicon-close" href="javascript://close" role="button" aria-label="Close"></a>
+                    <div class="elementor-cart__title" id="elementor-cart__title-4f2fbc29">
+                        Your Shopping Cart                    </div>
+                            <div class="elementor-cart__empty-message" role="alert" aria-live="polite">No products in the cart.</div>
+        <div class="elementor-cart__products ce-scrollbar-y--auto" role="list">
+                    </div>
+        <div class="elementor-cart__summary" role="list" aria-label="Your order">
+            <div class="elementor-cart__summary-label" role="term">0 items</div>
+            <div class="elementor-cart__summary-value" role="definition">₹ 0</div>
+                    <span class="elementor-cart__summary-label" role="term">Shipping</span>
+            <span class="elementor-cart__summary-value" role="definition"></span>
+            <strong class="elementor-cart__summary-label" role="term">Total</strong>
+            <strong class="elementor-cart__summary-value" role="definition">₹ 0</strong>
+        </div>
+        <div class="elementor-alert elementor-alert-warning" hidden role="alert" aria-live="polite">
+            <span class="elementor-alert-description"></span>
+        </div>
+        <footer class="elementor-cart__footer-buttons">
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-button--cart elementor-size-md">
+                    <span class="elementor-button-text">View Cart</span>
+                </a>
+            </div>
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/order" class="elementor-button elementor-button--checkout elementor-size-md"tabindex="-1" aria-disabled="true">
+                    <span class="elementor-button-text">Checkout</span>
+                </a>
+            </div>
+        </footer>
+        <!--<div class="snap_emi_txt"></div>
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="0" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="checkout_page"></span>
+	  --->                </div>
+            </dialog>        <div class="elementor-cart__toggle">
+            <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-size-sm" role="button" aria-label="Shopping Cart" aria-controls="elementor-cart__dialog-4f2fbc29" aria-expanded="false" aria-description="0 items">
+                <span class="elementor-button-icon" data-counter="0" aria-hidden="true">
+                    <i class="ceicon ceicon-cart-medium"></i>                </span>
+                <span class="elementor-button-text">₹ 0</span>
+            </a>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-59f2b638 elementor-widget elementor-widget-html" data-id="59f2b638" data-element_type="widget" data-widget_type="html.default">
+        <div class="elementor-widget-container"><div style="display: flex; justify-content: center; align-items: center; ">
+    <img class="chatbase-clone-button" src="https://backend.chatbase.co/storage/v1/object/public/chat-icons/034638ea-1510-464d-ab08-ddbf9415756f/9aYxyeB8gJrt1_7U9MRGL.jpg" alt="Chat" style="width: 35px; height: 35px; border-radius: 50%; cursor: pointer;">
+</div>
+</div>        </div>
+                <div class="elementor-element elementor-element-22b97774 elementor-absolute elementor-widget elementor-widget-ps-widget-module" data-id="22b97774" data-element_type="widget" data-settings="{&quot;_position&quot;:&quot;absolute&quot;}" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- whatsappchat -->
+</div>        </div>
+                <div class="elementor-element elementor-element-2a599a38 elementor-widget elementor-widget-spacer" data-id="2a599a38" data-element_type="widget" data-widget_type="spacer.default">
+        <div class="elementor-widget-container">        <div class="elementor-spacer">
+            <div class="elementor-spacer-inner"></div>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                    </div>
+        </div>
+        
+			
+		</header>
+		
+			
+<aside id="notifications">
+  <div class="container">
+    
+    
+    
+      </div>
+</aside>
+		
+		
+			
+	<section id="content" style="max-width: none">
+		<form id="add-to-cart-or-refresh" action="https://www.swisstimehouse.com/cart" method="post" hidden>
+			<input type="hidden" name="token" value="7c0cb7b2271365cbe5adb02c6fafe304">
+			<input type="hidden" name="id_product" value="125701" id="product_page_product_id">
+			<input type="hidden" name="id_customization" value="0" id="product_customization_id">
+			<input type="hidden" name="qty" value="1" id="quantity_wanted"
+				>
+			<input type="submit" class="ce-add-to-cart" data-button-action="add-to-cart">
+		</form>
+		        <div data-elementor-type="product" data-elementor-id="28170101" class="elementor elementor-28170101" id="product-details" data-product="{&quot;id_shop_default&quot;:&quot;1&quot;,&quot;id_manufacturer&quot;:&quot;21&quot;,&quot;id_supplier&quot;:&quot;0&quot;,&quot;reference&quot;:&quot;G1714&quot;,&quot;is_virtual&quot;:&quot;0&quot;,&quot;delivery_in_stock&quot;:&quot;&quot;,&quot;delivery_out_stock&quot;:&quot;&quot;,&quot;id_category_default&quot;:&quot;281&quot;,&quot;on_sale&quot;:&quot;0&quot;,&quot;online_only&quot;:&quot;0&quot;,&quot;ecotax&quot;:0,&quot;minimal_quantity&quot;:&quot;1&quot;,&quot;low_stock_threshold&quot;:null,&quot;low_stock_alert&quot;:&quot;0&quot;,&quot;price&quot;:&quot;\u20b9 34,997&quot;,&quot;unity&quot;:&quot;&quot;,&quot;unit_price_ratio&quot;:&quot;0.000000&quot;,&quot;additional_shipping_cost&quot;:&quot;0.000000&quot;,&quot;customizable&quot;:&quot;0&quot;,&quot;text_fields&quot;:&quot;0&quot;,&quot;uploadable_files&quot;:&quot;0&quot;,&quot;redirect_type&quot;:&quot;404&quot;,&quot;id_type_redirected&quot;:&quot;0&quot;,&quot;available_for_order&quot;:&quot;1&quot;,&quot;available_date&quot;:&quot;0000-00-00&quot;,&quot;show_condition&quot;:&quot;0&quot;,&quot;condition&quot;:&quot;new&quot;,&quot;show_price&quot;:&quot;1&quot;,&quot;indexed&quot;:&quot;1&quot;,&quot;visibility&quot;:&quot;both&quot;,&quot;cache_default_attribute&quot;:&quot;0&quot;,&quot;advanced_stock_management&quot;:&quot;0&quot;,&quot;date_add&quot;:&quot;2025-10-12 22:27:36&quot;,&quot;date_upd&quot;:&quot;2026-01-26 12:33:27&quot;,&quot;pack_stock_type&quot;:&quot;3&quot;,&quot;meta_description&quot;:&quot;Buy Casio Casio G1714 watch at lowest prices from Authorized Retailer in India - Swiss Time House with EMI option, Cash on Delivery, Free Shipping. Easy Retu...&quot;,&quot;meta_keywords&quot;:&quot;buy Casio Casio G1714 online, shop Casio watch, Casio G1714, shop G1714, shop Casio at lowest price, G-Shock Watches , Casio  Casio G1714&quot;,&quot;meta_title&quot;:&quot;Buy Casio Casio G1714 Watch in India I Swiss Time House&quot;,&quot;link_rewrite&quot;:&quot;casio-g1714&quot;,&quot;name&quot;:&quot;Casio G1714 - GM-B2100SD-1CDR G-Shock Watch&quot;,&quot;description&quot;:&quot;###############################################################################################################################################################################################################################################################&quot;,&quot;description_short&quot;:&quot;Casio G1714 Men&#039;s Watch with 2 Year National Warranty ( 1St Year International Warranty )&quot;,&quot;available_now&quot;:&quot;&quot;,&quot;available_later&quot;:&quot;&quot;,&quot;id&quot;:125701,&quot;id_product&quot;:125701,&quot;out_of_stock&quot;:2,&quot;new&quot;:0,&quot;id_product_attribute&quot;:0,&quot;quantity_wanted&quot;:1,&quot;extraContent&quot;:[],&quot;allow_oosp&quot;:0,&quot;category&quot;:&quot;g-shock-watches&quot;,&quot;category_name&quot;:&quot;G-Shock Watches&quot;,&quot;link&quot;:&quot;https:\/\/www.swisstimehouse.com\/casio-g1714&quot;,&quot;attribute_price&quot;:0,&quot;price_tax_exc&quot;:34997,&quot;price_without_reduction&quot;:49995,&quot;reduction&quot;:14999,&quot;specific_prices&quot;:{&quot;id_specific_price&quot;:&quot;13304522&quot;,&quot;id_specific_price_rule&quot;:&quot;0&quot;,&quot;id_cart&quot;:&quot;0&quot;,&quot;id_product&quot;:&quot;125701&quot;,&quot;id_shop&quot;:&quot;1&quot;,&quot;id_shop_group&quot;:&quot;0&quot;,&quot;id_currency&quot;:&quot;0&quot;,&quot;id_country&quot;:&quot;0&quot;,&quot;id_group&quot;:&quot;0&quot;,&quot;id_customer&quot;:&quot;0&quot;,&quot;id_product_attribute&quot;:&quot;0&quot;,&quot;price&quot;:&quot;-1.000000&quot;,&quot;from_quantity&quot;:&quot;1&quot;,&quot;reduction&quot;:&quot;0.300000&quot;,&quot;reduction_tax&quot;:&quot;1&quot;,&quot;reduction_type&quot;:&quot;percentage&quot;,&quot;from&quot;:&quot;2026-05-18 00:00:00&quot;,&quot;to&quot;:&quot;2027-03-31 23:59:59&quot;,&quot;score&quot;:&quot;48&quot;},&quot;quantity&quot;:2,&quot;quantity_all_versions&quot;:2,&quot;id_image&quot;:&quot;en-default&quot;,&quot;features&quot;:[{&quot;name&quot;:&quot;Gender&quot;,&quot;value&quot;:&quot;Men&quot;,&quot;id_feature&quot;:&quot;34&quot;,&quot;position&quot;:&quot;0&quot;},{&quot;name&quot;:&quot;Watch Type&quot;,&quot;value&quot;:&quot;Analog-Digital&quot;,&quot;id_feature&quot;:&quot;42&quot;,&quot;position&quot;:&quot;10&quot;},{&quot;name&quot;:&quot;Price Range&quot;,&quot;value&quot;:&quot;30000 - 50000&quot;,&quot;id_feature&quot;:&quot;74&quot;,&quot;position&quot;:&quot;11&quot;},{&quot;name&quot;:&quot;Collection&quot;,&quot;value&quot;:&quot;G-SHOCK&quot;,&quot;id_feature&quot;:&quot;47&quot;,&quot;position&quot;:&quot;12&quot;},{&quot;name&quot;:&quot;For&quot;,&quot;value&quot;:&quot;Male&quot;,&quot;id_feature&quot;:&quot;73&quot;,&quot;position&quot;:&quot;13&quot;},{&quot;name&quot;:&quot;Series&quot;,&quot;value&quot;:&quot;GM-B2100&quot;,&quot;id_feature&quot;:&quot;36&quot;,&quot;position&quot;:&quot;14&quot;},{&quot;name&quot;:&quot;Warranty&quot;,&quot;value&quot;:&quot;2 Year National Warranty ( 1St Year International Warranty )&quot;,&quot;id_feature&quot;:&quot;46&quot;,&quot;position&quot;:&quot;16&quot;},{&quot;name&quot;:&quot;Glass Material&quot;,&quot;value&quot;:&quot;Mineral Glass&quot;,&quot;id_feature&quot;:&quot;10&quot;,&quot;position&quot;:&quot;17&quot;},{&quot;name&quot;:&quot;Water Resistance (M)&quot;,&quot;value&quot;:&quot;Y&quot;,&quot;id_feature&quot;:&quot;9&quot;,&quot;position&quot;:&quot;18&quot;},{&quot;name&quot;:&quot;Case Material&quot;,&quot;value&quot;:&quot;Stainless steel&quot;,&quot;id_feature&quot;:&quot;17&quot;,&quot;position&quot;:&quot;28&quot;},{&quot;name&quot;:&quot;Case Shape&quot;,&quot;value&quot;:&quot;Octagonal&quot;,&quot;id_feature&quot;:&quot;11&quot;,&quot;position&quot;:&quot;29&quot;},{&quot;name&quot;:&quot;Case Specificities&quot;,&quot;value&quot;:&quot;165g&quot;,&quot;id_feature&quot;:&quot;52&quot;,&quot;position&quot;:&quot;30&quot;},{&quot;name&quot;:&quot;Case Size&quot;,&quot;value&quot;:&quot;49.8X44.4X12.8 mm&quot;,&quot;id_feature&quot;:&quot;15&quot;,&quot;position&quot;:&quot;31&quot;},{&quot;name&quot;:&quot;Band Material&quot;,&quot;value&quot;:&quot;One-touch 3-fold clasp&quot;,&quot;id_feature&quot;:&quot;14&quot;,&quot;position&quot;:&quot;38&quot;},{&quot;name&quot;:&quot;Band Material&quot;,&quot;value&quot;:&quot;Stainless Steel&quot;,&quot;id_feature&quot;:&quot;14&quot;,&quot;position&quot;:&quot;38&quot;},{&quot;name&quot;:&quot;Band Material&quot;,&quot;value&quot;:&quot;Solid Band&quot;,&quot;id_feature&quot;:&quot;14&quot;,&quot;position&quot;:&quot;38&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Stopwatch&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Hand Shift Feature&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Hourly Time Signal&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Solar Powered&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Countdown Timer&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Alarm (s)&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;World Time&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Tough Solar&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;LED Light&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Super Illuminator&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Neobrite Hands&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Water Resistance&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Bluetooth&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Auto Calendar&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Shock Resistant&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Solid Band&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Features&quot;,&quot;value&quot;:&quot;Phone Finder&quot;,&quot;id_feature&quot;:&quot;16&quot;,&quot;position&quot;:&quot;44&quot;},{&quot;name&quot;:&quot;Ranking&quot;,&quot;value&quot;:&quot;8&quot;,&quot;id_feature&quot;:&quot;45&quot;,&quot;position&quot;:&quot;52&quot;}],&quot;attachments&quot;:[],&quot;virtual&quot;:0,&quot;pack&quot;:0,&quot;packItems&quot;:[],&quot;nopackprice&quot;:0,&quot;customization_required&quot;:false,&quot;rate&quot;:0,&quot;tax_name&quot;:&quot;&quot;,&quot;ecotax_rate&quot;:0,&quot;unit_price&quot;:&quot;&quot;,&quot;customizations&quot;:{&quot;fields&quot;:[]},&quot;id_customization&quot;:0,&quot;is_customizable&quot;:false,&quot;show_quantities&quot;:false,&quot;quantity_label&quot;:&quot;Items&quot;,&quot;quantity_discounts&quot;:[],&quot;customer_group_discount&quot;:0,&quot;images&quot;:[{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196159&quot;,&quot;cover&quot;:&quot;1&quot;,&quot;position&quot;:&quot;1&quot;,&quot;associatedVariants&quot;:[]},{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196160-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196160&quot;,&quot;cover&quot;:null,&quot;position&quot;:&quot;2&quot;,&quot;associatedVariants&quot;:[]},{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196161-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196161&quot;,&quot;cover&quot;:null,&quot;position&quot;:&quot;3&quot;,&quot;associatedVariants&quot;:[]},{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196162-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196162&quot;,&quot;cover&quot;:null,&quot;position&quot;:&quot;4&quot;,&quot;associatedVariants&quot;:[]},{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196163-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196163&quot;,&quot;cover&quot;:null,&quot;position&quot;:&quot;5&quot;,&quot;associatedVariants&quot;:[]}],&quot;cover&quot;:{&quot;bySize&quot;:{&quot;small_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;cart_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-cart_default\/casio-g1714.jpg&quot;,&quot;width&quot;:125,&quot;height&quot;:162},&quot;large_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-large_default\/casio-g1714.jpg&quot;,&quot;width&quot;:419,&quot;height&quot;:541},&quot;home_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;medium_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-medium_default\/casio-g1714.jpg&quot;,&quot;width&quot;:452,&quot;height&quot;:584},&quot;thickbox_default&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422}},&quot;small&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-small_default\/casio-g1714.jpg&quot;,&quot;width&quot;:98,&quot;height&quot;:127},&quot;medium&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-home_default\/casio-g1714.jpg&quot;,&quot;width&quot;:440,&quot;height&quot;:569},&quot;large&quot;:{&quot;url&quot;:&quot;https:\/\/www.swisstimehouse.com\/196159-thickbox_default\/casio-g1714.jpg&quot;,&quot;width&quot;:1100,&quot;height&quot;:1422},&quot;legend&quot;:&quot;&quot;,&quot;id_image&quot;:&quot;196159&quot;,&quot;cover&quot;:&quot;1&quot;,&quot;position&quot;:&quot;1&quot;,&quot;associatedVariants&quot;:[]},&quot;has_discount&quot;:true,&quot;discount_type&quot;:&quot;percentage&quot;,&quot;discount_percentage&quot;:&quot;-30%&quot;,&quot;discount_percentage_absolute&quot;:&quot;30%&quot;,&quot;discount_amount&quot;:&quot;\u20b9 14,999&quot;,&quot;discount_amount_to_display&quot;:&quot;-\u20b9 14,999&quot;,&quot;price_amount&quot;:34997,&quot;unit_price_full&quot;:&quot;&quot;,&quot;show_availability&quot;:true,&quot;availability_date&quot;:null,&quot;availability_message&quot;:&quot;In Stock&quot;,&quot;availability&quot;:&quot;available&quot;}">
+            <div class="elementor-section-wrap">
+                        <section class="elementor-element elementor-element-f737d3 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="f737d3" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-6cb28dd3 elementor-column elementor-col-100 elementor-top-column" data-id="6cb28dd3" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-734e6f54 elementor-widget__width-inherit elementor-widget elementor-widget-breadcrumb" data-id="734e6f54" data-element_type="widget" data-widget_type="breadcrumb.default">
+        <div class="elementor-widget-container">        <nav class="ce-breadcrumb" data-depth="7" aria-label="Breadcrumb">
+            <ol class="elementor-row">
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/">Home</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/products">Products</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/watches">Watches</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/accessible-desirable-brands">Accessible & Desirable Brands</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/casio-watches">Casio Watches</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <a href="https://www.swisstimehouse.com/g-shock-watches">G-Shock Watches</a>
+                                </li>
+                            <li class="ce-breadcrumb__item">
+                                    <span aria-current="page">Casio G1714 - GM-B2100SD-1CDR G-Shock Watch</span>
+                                </li>
+                        </ol>
+        </nav>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-48730c56 elementor-hidden-desktop elementor-hidden-tablet elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="48730c56" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-68f251ea elementor-column elementor-col-100 elementor-top-column" data-id="68f251ea" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-1f3d2b26 elementor-hidden-desktop elementor-hidden-tablet elementor-skin-carousel elementor-arrows-yes elementor-pagination-type-bullets elementor-pagination-position-outside elementor-widget elementor-widget-product-images" data-id="1f3d2b26" data-element_type="widget" data-settings="{&quot;skin&quot;:&quot;carousel&quot;,&quot;effect&quot;:&quot;flip&quot;,&quot;loop&quot;:&quot;yes&quot;,&quot;show_arrows&quot;:&quot;yes&quot;,&quot;pagination&quot;:&quot;bullets&quot;,&quot;speed&quot;:500}" data-widget_type="product-images.default">
+        <div class="elementor-widget-container">        <div class="elementor-swiper">
+            <div class="elementor-main-swiper swiper swiper-custom" role="region" aria-roledescription="carousel" aria-label="Product Images">
+                <div class="swiper-wrapper">
+                                    <div class="swiper-slide swiper-initial-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner" href="/img/p/1/9/6/1/5/9/196159.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="1f3d2b26">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196159-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="high">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner" href="/img/p/1/9/6/1/6/0/196160.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="1f3d2b26">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196160-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner" href="/img/p/1/9/6/1/6/1/196161.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="1f3d2b26">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196161-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner" href="/img/p/1/9/6/1/6/2/196162.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="1f3d2b26">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196162-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner" href="/img/p/1/9/6/1/6/3/196163.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="1f3d2b26">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196163-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                </div>
+                            <div class="elementor-swiper-button elementor-swiper-button-prev" role="button" tabindex="0" aria-label="Previous">
+                    <i class="fas fa-caret-left"></i>                </div>
+                <div class="elementor-swiper-button elementor-swiper-button-next" role="button" tabindex="0" aria-label="Next">
+                    <i class="fas fa-caret-right"></i>                </div>
+                                        <div class="swiper-pagination"></div>
+                        </div>
+        </div>
+                </div>        </div>
+                <div class="elementor-element elementor-element-6ca9c2e0 elementor-widget__width-auto elementor-absolute ce-product-badges--inline elementor-widget elementor-widget-product-badges elementor-overflow-hidden" data-id="6ca9c2e0" data-element_type="widget" data-settings="{&quot;_position&quot;:&quot;absolute&quot;}" data-widget_type="product-badges.default">
+        <div class="elementor-widget-container">        <div class="ce-product-badges">
+                    <div class="ce-product-badge ce-product-badge-sale">-30%</div>
+                </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-5085f74 elementor-section-full_width elementor-hidden-phone elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="5085f74" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-extended">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-19dc8491 ce-valign-space-between elementor-column elementor-col-33 elementor-top-column" data-id="19dc8491" data-element_type="column">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-5e8842ac elementor-column elementor-col-33 elementor-top-column" data-id="5e8842ac" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-2b618e49 elementor-column elementor-col-33 elementor-top-column" data-id="2b618e49" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <section class="elementor-element elementor-element-12f76351 elementor-section-height-min-height elementor-section-boxed elementor-section-height-default elementor-section elementor-inner-section" data-id="12f76351" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-38681926 ce-valign-space-between elementor-column elementor-col-100 elementor-inner-column" data-id="38681926" data-element_type="column">
+            <div class="elementor-column-wrap">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-a2da372 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="a2da372" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-extended">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-2464722e ce-valign-space-between elementor-column elementor-col-33 elementor-top-column" data-id="2464722e" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-afb5191 elementor-widget elementor-widget-product-name elementor-widget-heading" data-id="afb5191" data-element_type="widget" data-widget_type="product-name.default">
+        <div class="elementor-widget-container"><h1 class="ce-product-name ce-product-name--full elementor-heading-title">Casio G1714 - GM-B2100SD-1CDR G-Shock Watch</h1></div>        </div>
+                <div class="elementor-element elementor-element-747db6cc elementor-widget elementor-widget-product-features elementor-widget-heading" data-id="747db6cc" data-element_type="widget" data-widget_type="product-features.default">
+        <div class="elementor-widget-container">        <table class="ce-product-features" aria-label="Product Features">
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Collection</th>
+                <td class="ce-product-features__value">G-SHOCK</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Series</th>
+                <td class="ce-product-features__value">GM-B2100</td>
+            </tr>
+                </table>
+        </div>        </div>
+                <div class="elementor-element elementor-element-346305e elementor-widget__width-initial elementor-widget-tablet__width-inherit elementor-widget elementor-widget-product-description-short elementor-widget-text-editor" data-id="346305e" data-element_type="widget" data-widget_type="product-description-short.default">
+        <div class="ce-product-description-short elementor-widget-container">Casio G1714 Men's Watch with 2 Year National Warranty ( 1St Year International Warranty )</div>        </div>
+                <div class="elementor-element elementor-element-3851aa9e elementor-widget elementor-widget-shortcode" data-id="3851aa9e" data-element_type="widget" id="custom_reviewBlock" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container"><div class="aggregateratingcustom" style="text-align: center;">
+    
+
+</div>
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-64d2002a ce-valign-space-between elementor-hidden-phone elementor-column elementor-col-33 elementor-top-column" data-id="64d2002a" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-2d48556d elementor-hidden-phone elementor-skin-slideshow elementor-position-bottom elementor-arrows-yes elementor-widget elementor-widget-product-images" data-id="2d48556d" data-element_type="widget" data-settings="{&quot;slides_per_view&quot;:&quot;4&quot;,&quot;thumb_space_between&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:15,&quot;sizes&quot;:[]},&quot;skin&quot;:&quot;slideshow&quot;,&quot;effect&quot;:&quot;slide&quot;,&quot;position&quot;:&quot;bottom&quot;,&quot;show_arrows&quot;:&quot;yes&quot;,&quot;speed&quot;:500,&quot;thumb_space_between_tablet&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;thumb_space_between_mobile&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]}}" data-widget_type="product-images.default">
+        <div class="elementor-widget-container">        <div class="elementor-swiper">
+            <div class="elementor-main-swiper swiper swiper-custom" role="region" aria-roledescription="carousel" aria-label="Product Images">
+                <div class="swiper-wrapper">
+                                    <div class="swiper-slide swiper-initial-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner swiper-zoom-container" href="/img/p/1/9/6/1/5/9/196159.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d" data-swiper-zoom="1.7">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196159-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="high">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner swiper-zoom-container" href="/img/p/1/9/6/1/6/0/196160.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d" data-swiper-zoom="1.7">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196160-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner swiper-zoom-container" href="/img/p/1/9/6/1/6/1/196161.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d" data-swiper-zoom="1.7">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196161-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner swiper-zoom-container" href="/img/p/1/9/6/1/6/2/196162.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d" data-swiper-zoom="1.7">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196162-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                    <div class="swiper-slide" role="group" aria-roledescription="slide">
+                                            <a class="swiper-slide-inner swiper-zoom-container" href="/img/p/1/9/6/1/6/3/196163.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d" data-swiper-zoom="1.7">
+                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196163-home_default/casio-g1714.jpg" alt="" width="440" height="569" fetchpriority="low" loading="lazy">
+                                                    <div class="elementor-carousel-image-overlay e-overlay-animation-fade">
+                                <i aria-hidden="false" class="fas fa-expand"></i>                            </div>
+                                                </a>
+                                        </div>
+                                </div>
+                            <div class="elementor-swiper-button elementor-swiper-button-prev" role="button" tabindex="0" aria-label="Previous">
+                    <i class="ceicon-chevron-left"></i>                </div>
+                <div class="elementor-swiper-button elementor-swiper-button-next" role="button" tabindex="0" aria-label="Next">
+                    <i class="ceicon-chevron-right"></i>                </div>
+                                    </div>
+        </div>
+                    <div class="elementor-swiper">
+                <div class="elementor-thumbnails-swiper swiper swiper swiper-custom" role="region" aria-roledescription="carousel" aria-label="Thumbnails">
+                    <div class="swiper-wrapper">
+                                            <div class="swiper-slide" role="group" aria-roledescription="slide">
+                        <a href="/img/p/1/9/6/1/5/9/196159.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d-thumb">                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196159-small_default/casio-g1714.jpg" alt="" width="98" height="127" fetchpriority="high">
+                            </a>                                                </div>
+                                            <div class="swiper-slide" role="group" aria-roledescription="slide">
+                        <a href="/img/p/1/9/6/1/6/0/196160.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d-thumb">                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196160-small_default/casio-g1714.jpg" alt="" width="98" height="127" fetchpriority="high">
+                            </a>                                                </div>
+                                            <div class="swiper-slide" role="group" aria-roledescription="slide">
+                        <a href="/img/p/1/9/6/1/6/1/196161.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d-thumb">                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196161-small_default/casio-g1714.jpg" alt="" width="98" height="127" fetchpriority="high">
+                            </a>                                                </div>
+                                            <div class="swiper-slide" role="group" aria-roledescription="slide">
+                        <a href="/img/p/1/9/6/1/6/2/196162.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d-thumb">                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196162-small_default/casio-g1714.jpg" alt="" width="98" height="127" fetchpriority="high">
+                            </a>                                                </div>
+                                            <div class="swiper-slide" role="group" aria-roledescription="slide">
+                        <a href="/img/p/1/9/6/1/6/3/196163.jpg" data-elementor-open-lightbox="yes" data-elementor-lightbox-slideshow="2d48556d-thumb">                            <img class="elementor-carousel-image" src="https://www.swisstimehouse.com/196163-small_default/casio-g1714.jpg" alt="" width="98" height="127" fetchpriority="low" loading="lazy">
+                            </a>                                                </div>
+                                        </div>
+                    <div class="swiper-scrollbar"></div>
+                </div>
+            </div>
+                </div>        </div>
+                <div class="elementor-element elementor-element-1732f7df elementor-widget__width-auto elementor-absolute ce-product-badges--inline elementor-widget elementor-widget-product-badges elementor-overflow-hidden" data-id="1732f7df" data-element_type="widget" data-settings="{&quot;_position&quot;:&quot;absolute&quot;}" data-widget_type="product-badges.default">
+        <div class="elementor-widget-container">        <div class="ce-product-badges">
+                    <div class="ce-product-badge ce-product-badge-sale">-30%</div>
+                </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-2837bef ce-valign-space-between elementor-column elementor-col-33 elementor-top-column" data-id="2837bef" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-6a7bcd69 elementor-mobile-align-center ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="6a7bcd69" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__reference" role="listitem">   <span class="ce-product-meta__label">SKU</span>   <span class="ce-product-meta__value">G1714</span></span></div></div>        </div>
+                <div class="elementor-element elementor-element-b495767 ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="b495767" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"></div></div>        </div>
+                <div class="elementor-element elementor-element-6f89b325 ce-product-badges--inline elementor-widget elementor-widget-product-badges elementor-overflow-hidden" data-id="6f89b325" data-element_type="widget" data-widget_type="product-badges.default">
+        <div class="elementor-widget-container">        <div class="ce-product-badges">
+                    <div class="ce-product-badge ce-product-badge-sale">-30%</div>
+                </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-7b3842f2 ce-product-prices--layout-inline current-price elementor-mobile-align-center elementor-widget elementor-widget-product-price elementor-overflow-hidden" data-id="7b3842f2" data-element_type="widget" data-widget_type="product-price.default">
+        <div class="elementor-widget-container"><div style="display:none" class="jay">IN G-Shock Watches Casio</div>		
+        <div class="ce-product-prices">
+                                <del class="ce-product-price-regular"><span class="screen-reader-text">Regular price:</span> ₹ 49,995</del>
+                    <div class="ce-product-price ce-has-discount">
+                <span class="screen-reader-text">Reduced price:</span>
+                <span>₹ 34,997</span
+                                    ><span class="ce-product-badge ce-product-badge-sale ce-product-badge-sale-percentage">
+                    Save 30%                </span
+                    >
+            </div>
+                                                                <div class="ce-tax-shipping-delivery-label">Tax included                    <div class="snap_emi_txt"></div>
+
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="34997" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="products_page"></span>
+
+<script>
+    (function () {
+        var snapmint = document.createElement('script');
+        snapmint.type = 'text/javascript';
+        snapmint.async = true;
+        snapmint.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 
+            'merchant-js.snapmint.com/assets/merchant/4797/snapmint_emi.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(snapmint, s);
+    })();
+</script></div>
+                </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-369c7da0 elementor-countdown--label-block elementor-widget elementor-widget-product-sale-countdown elementor-widget-countdown" data-id="369c7da0" data-element_type="widget" data-widget_type="product-sale-countdown.default">
+        <div class="elementor-widget-container">         </div>        </div>
+                <div class="elementor-element elementor-element-671266e9 ce-product-quantity--view-inline elementor-widget__width-auto elementor-mobile-align-center elementor-widget elementor-widget-product-quantity" data-id="671266e9" data-element_type="widget" data-widget_type="product-quantity.default">
+        <div class="elementor-widget-container">        <div class="ce-product-quantity elementor-field-group">
+            <i class="ce-product-quantity__btn ce-product-quantity__minus fas fa-minus" onclick="this.nextElementSibling.stepDown(), $(this.nextElementSibling).trigger('input')" aria-hidden="true"></i>
+            <input type="number" form="add-to-cart-or-refresh" name="qty" value="1" min="1" class="elementor-field elementor-field-textual elementor-size-sm" aria-label="Quantity" inputmode="decimal" oninput="$(this.form.qty).val(this.value)">
+            <i class="ce-product-quantity__btn ce-product-quantity__plus fas fa-plus" onclick="this.previousElementSibling.stepUp(), $(this.previousElementSibling).trigger('input')" aria-hidden="true"></i>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-b9b1c10 elementor-widget__width-auto elementor-widget elementor-widget-product-stock" data-id="b9b1c10" data-element_type="widget" data-widget_type="product-stock.default">
+        <div class="elementor-widget-container">        <div class="ce-product-stock">
+                    <div class="ce-product-stock__availability ce-product-stock--in-stock" role="status" aria-live="polite">
+                            <i class="ceicon ceicon-check" aria-hidden="true"></i>
+                            <span class="ce-product-stock__availability-label">In Stock</span>
+            </div>
+                        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-2a700d2f elementor-view-stacked elementor-widget__width-auto elementor-shape-square elementor-hidden-desktop elementor-hidden-tablet elementor-hidden-phone elementor-widget elementor-widget-product-add-to-wishlist elementor-widget-icon" data-id="2a700d2f" data-element_type="widget" data-widget_type="product-add-to-wishlist.default">
+        <div class="elementor-widget-container">        <a class="ce-add-to-wishlist elementor-icon" data-product-id="125701" data-product-attribute-id="0" role="button" aria-label="Add to wishlist" href="https://www.swisstimehouse.com/module/blockwishlist/action">
+            <i aria-hidden="true" class="ceicon-heart-o"></i>        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-65e1a138 elementor-widget elementor-widget-ps-widget-module" data-id="65e1a138" data-element_type="widget" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- hioutofstocknotification -->
+</div>        </div>
+                <div class="elementor-element elementor-element-1ab3adc elementor-widget elementor-widget-shortcode" data-id="1ab3adc" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container">    <div class="actual-qty" data-customer-group="1">
+        <strong>2</strong> items available
+    </div>
+    <div class="cartbuttonsj"> 
+            </div>
+    
+
+
+
+</div>        </div>
+                <div class="elementor-element elementor-element-1d605a11 elementor-button-primary elementor-align-justify elementor-widget__width-inherit remove_on_cfp elementor-widget elementor-widget-product-add-to-cart elementor-widget-button" data-id="1d605a11" data-element_type="widget" data-widget_type="product-add-to-cart.default">
+        <div class="elementor-widget-container">        <a href="#ce-action=addToCart" role="button" class="elementor-button elementor-size-lg">
+            <span class="elementor-button-content-wrapper">
+                        <span class="elementor-button-icon elementor-align-icon-left" aria-hidden="true"><i class="ceicon-basket-solid"></i></span>
+                                    <span class="elementor-button-text">Add to Cart</span>
+                        </span>
+        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-6ac99a72 elementor-align-justify elementor-widget__width-inherit remove_on_cfp elementor-hidden-desktop elementor-hidden-tablet elementor-hidden-phone elementor-widget elementor-widget-product-add-to-cart elementor-widget-button" data-id="6ac99a72" data-element_type="widget" data-widget_type="product-add-to-cart.default">
+        <div class="elementor-widget-container">        <a href="#ce-action=buyNow" role="button" class="elementor-button elementor-size-lg">
+            <span class="elementor-button-content-wrapper">
+                        <span class="elementor-button-icon elementor-align-icon-left" aria-hidden="true"><i class="ceicon ceicon-cart-solid"></i></span>
+                                    <span class="elementor-button-text">Buy Now</span>
+                        </span>
+        </a>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-796c3c4 elementor-section-full_width elementor-hidden-desktop elementor-hidden-tablet elementor-hidden-phone elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="796c3c4" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-extended">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-1fa442a ce-valign-space-between elementor-column elementor-col-50 elementor-top-column" data-id="1fa442a" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-b5067ba elementor-widget elementor-widget-manufacturer-image elementor-widget-image" data-id="b5067ba" data-element_type="widget" data-widget_type="manufacturer-image.default">
+        <div class="elementor-widget-container"><a href="https://www.swisstimehouse.com/manufacturer/casio"><img src="https://www.swisstimehouse.com/img/m/21.jpg" alt="logo" loading="lazy"></a></div>        </div>
+                <div class="elementor-element elementor-element-d44bf6f elementor-widget__width-initial elementor-widget elementor-widget-product-name elementor-widget-heading" data-id="d44bf6f" data-element_type="widget" data-widget_type="product-name.default">
+        <div class="elementor-widget-container"><h1 class="ce-product-name ce-product-name--full elementor-heading-title">Add Your Heading Text Here</h1></div>        </div>
+                <div class="elementor-element elementor-element-8d82ddd elementor-widget elementor-widget-product-features elementor-widget-heading" data-id="8d82ddd" data-element_type="widget" data-widget_type="product-features.default">
+        <div class="elementor-widget-container">        <table class="ce-product-features" aria-label="Product Features">
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Collection</th>
+                <td class="ce-product-features__value">G-SHOCK</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Series</th>
+                <td class="ce-product-features__value">GM-B2100</td>
+            </tr>
+                </table>
+        </div>        </div>
+                <div class="elementor-element elementor-element-4a489e2 elementor-widget__width-initial elementor-widget-tablet__width-inherit elementor-widget elementor-widget-product-description-short elementor-widget-text-editor" data-id="4a489e2" data-element_type="widget" data-widget_type="product-description-short.default">
+        <div class="ce-product-description-short elementor-widget-container">Casio G1714 Men's Watch with 2 Year National Warranty ( 1St Year International Warranty )</div>        </div>
+                <div class="elementor-element elementor-element-e897c85 elementor-widget elementor-widget-shortcode" data-id="e897c85" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container"><div class="aggregateratingcustom" style="text-align: center;">
+    
+
+</div>
+</div>        </div>
+                <div class="elementor-element elementor-element-fb6fc4b elementor-widget__width-initial elementor-widget elementor-widget-heading" data-id="fb6fc4b" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><span class="elementor-heading-title">Share</span></div>        </div>
+                <div class="elementor-element elementor-element-cb441db elementor-shape-circle elementor-widget__width-auto elementor-grid-0 elementor-widget elementor-widget-product-share elementor-widget-social-icons" data-id="cb441db" data-element_type="widget" data-widget_type="product-share.default">
+        <div class="elementor-widget-container">        <div class="elementor-social-icons-wrapper elementor-grid" role="list">
+                    <span class="elementor-grid-item" role="listitem">
+                <a aria-label="Share on Facebook" class="elementor-icon elementor-social-icon elementor-social-icon-facebook elementor-repeater-item-d062134" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.swisstimehouse.com%2Fcasio-g1714" target="_blank">
+                    <i class="fab fa-facebook"></i>                </a>
+            </span>
+                    <span class="elementor-grid-item" role="listitem">
+                <a aria-label="Share on X Twitter" class="elementor-icon elementor-social-icon elementor-social-icon-x-twitter elementor-repeater-item-389bb74" href="https://twitter.com/intent/tweet?text=Casio%20G1714%20-%20GM-B2100SD-1CDR%20G-Shock%20Watch%0Ahttps%3A%2F%2Fwww.swisstimehouse.com%2Fcasio-g1714" target="_blank">
+                    <i class="fab fa-x-twitter"></i>                </a>
+            </span>
+                </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-5c2e10d elementor-align-left elementor-icon-list--layout-traditional elementor-list-item-link-full_width elementor-widget elementor-widget-icon-list" data-id="5c2e10d" data-element_type="widget" data-widget_type="icon-list.default">
+        <div class="elementor-widget-container">        <ul class="elementor-icon-list-items">
+                    <li class="elementor-icon-list-item">
+            <a href="#shopinstoreblock">                            <span class="elementor-icon-list-icon" aria-hidden="true"><i class="fas fa-store"></i></span>
+                            <span class="elementor-icon-list-text">Pick up in store</span>
+            </a>            </li>
+                    <li class="elementor-icon-list-item">
+            <a href="#fast-shipping">                            <span class="elementor-icon-list-icon" aria-hidden="true"><i class="fas fa-plane-departure"></i></span>
+                            <span class="elementor-icon-list-text">Safe and Fast Shipping</span>
+            </a>            </li>
+                    <li class="elementor-icon-list-item">
+            <a href="https://www.swisstimehouse.com/return-policy">                            <span class="elementor-icon-list-icon" aria-hidden="true"><i class="fas fa-shield-halved"></i></span>
+                            <span class="elementor-icon-list-text">Return Policy</span>
+            </a>            </li>
+                    <li class="elementor-icon-list-item">
+            <a href="#swiss-time-house-payment">                            <span class="elementor-icon-list-icon" aria-hidden="true"><i class="far fa-credit-card"></i></span>
+                            <span class="elementor-icon-list-text">Secure Payment</span>
+            </a>            </li>
+                    <li class="elementor-icon-list-item">
+            <a href="https://www.swisstimehouse.com/contact-us">                            <span class="elementor-icon-list-icon" aria-hidden="true"><i class="fas fa-circle-question"></i></span>
+                            <span class="elementor-icon-list-text">Ask a Question</span>
+            </a>            </li>
+                </ul>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-439969f ce-valign-space-between elementor-column elementor-col-50 elementor-top-column" data-id="439969f" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-93d464b elementor-mobile-align-center ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="93d464b" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__category" role="listitem">   <span class="ce-product-meta__label">Category</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/g-shock-watches">G-Shock Watches</a></span></span></div></div>        </div>
+                <div class="elementor-element elementor-element-6f95297 elementor-mobile-align-center ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="6f95297" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__manufacturer" role="listitem">   <span class="ce-product-meta__label">Brand</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/manufacturer/casio">Casio</a></span></span></div></div>        </div>
+                <div class="elementor-element elementor-element-d30cae5 elementor-mobile-align-center ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="d30cae5" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__reference" role="listitem">   <span class="ce-product-meta__label">SKU</span>   <span class="ce-product-meta__value">G1714</span></span></div></div>        </div>
+                <div class="elementor-element elementor-element-1d348b4 ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="1d348b4" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"></div></div>        </div>
+                <div class="elementor-element elementor-element-71a29d7 ce-product-badges--inline elementor-widget elementor-widget-product-badges elementor-overflow-hidden" data-id="71a29d7" data-element_type="widget" data-widget_type="product-badges.default">
+        <div class="elementor-widget-container">        <div class="ce-product-badges">
+                    <div class="ce-product-badge ce-product-badge-sale">-30%</div>
+                </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-5dfce46 ce-product-prices--layout-inline current-price elementor-mobile-align-center elementor-widget elementor-widget-product-price elementor-overflow-hidden" data-id="5dfce46" data-element_type="widget" data-widget_type="product-price.default">
+        <div class="elementor-widget-container"><div style="display:none" class="jay">IN G-Shock Watches Casio</div>		
+        <div class="ce-product-prices">
+                                <del class="ce-product-price-regular"><span class="screen-reader-text">Regular price:</span> ₹ 49,995</del>
+                    <div class="ce-product-price ce-has-discount">
+                <span class="screen-reader-text">Reduced price:</span>
+                <span>₹ 34,997</span
+                                    ><span class="ce-product-badge ce-product-badge-sale ce-product-badge-sale-percentage">
+                    Save 30%                </span
+                    >
+            </div>
+                                                                <div class="ce-tax-shipping-delivery-label">Tax included                    <div class="snap_emi_txt"></div>
+
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="34997" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="products_page"></span>
+
+<script>
+    (function () {
+        var snapmint = document.createElement('script');
+        snapmint.type = 'text/javascript';
+        snapmint.async = true;
+        snapmint.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 
+            'merchant-js.snapmint.com/assets/merchant/4797/snapmint_emi.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(snapmint, s);
+    })();
+</script></div>
+                </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-f599e1b elementor-countdown--label-block elementor-widget elementor-widget-product-sale-countdown elementor-widget-countdown" data-id="f599e1b" data-element_type="widget" data-widget_type="product-sale-countdown.default">
+        <div class="elementor-widget-container">         </div>        </div>
+                <div class="elementor-element elementor-element-c16510d ce-product-quantity--view-inline elementor-widget__width-auto elementor-mobile-align-center elementor-widget elementor-widget-product-quantity" data-id="c16510d" data-element_type="widget" data-widget_type="product-quantity.default">
+        <div class="elementor-widget-container">        <div class="ce-product-quantity elementor-field-group">
+            <i class="ce-product-quantity__btn ce-product-quantity__minus fas fa-minus" onclick="this.nextElementSibling.stepDown(), $(this.nextElementSibling).trigger('input')" aria-hidden="true"></i>
+            <input type="number" form="add-to-cart-or-refresh" name="qty" value="1" min="1" class="elementor-field elementor-field-textual elementor-size-sm" aria-label="Quantity" inputmode="decimal" oninput="$(this.form.qty).val(this.value)">
+            <i class="ce-product-quantity__btn ce-product-quantity__plus fas fa-plus" onclick="this.previousElementSibling.stepUp(), $(this.previousElementSibling).trigger('input')" aria-hidden="true"></i>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-973d4d4 elementor-widget__width-auto elementor-widget elementor-widget-product-stock" data-id="973d4d4" data-element_type="widget" data-widget_type="product-stock.default">
+        <div class="elementor-widget-container">        <div class="ce-product-stock">
+                    <div class="ce-product-stock__availability ce-product-stock--in-stock" role="status" aria-live="polite">
+                            <i class="ceicon ceicon-check" aria-hidden="true"></i>
+                            <span class="ce-product-stock__availability-label">In Stock</span>
+            </div>
+                        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-f0bb9f4 elementor-view-stacked elementor-widget__width-auto elementor-shape-square elementor-hidden-desktop elementor-hidden-tablet elementor-hidden-phone elementor-widget elementor-widget-product-add-to-wishlist elementor-widget-icon" data-id="f0bb9f4" data-element_type="widget" data-widget_type="product-add-to-wishlist.default">
+        <div class="elementor-widget-container">        <a class="ce-add-to-wishlist elementor-icon" data-product-id="125701" data-product-attribute-id="0" role="button" aria-label="Add to wishlist" href="https://www.swisstimehouse.com/module/blockwishlist/action">
+            <i aria-hidden="true" class="ceicon-heart-o"></i>        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-164fa0e elementor-widget elementor-widget-ps-widget-module" data-id="164fa0e" data-element_type="widget" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- hioutofstocknotification -->
+</div>        </div>
+                <div class="elementor-element elementor-element-dfbb247 elementor-widget elementor-widget-shortcode" data-id="dfbb247" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container">    <div class="actual-qty" data-customer-group="1">
+        <strong>2</strong> items available
+    </div>
+    <div class="cartbuttonsj"> 
+            </div>
+    
+
+
+
+</div>        </div>
+                <div class="elementor-element elementor-element-e839fa4 elementor-button-primary elementor-align-justify elementor-widget__width-inherit remove_on_cfp elementor-widget elementor-widget-product-add-to-cart elementor-widget-button" data-id="e839fa4" data-element_type="widget" data-widget_type="product-add-to-cart.default">
+        <div class="elementor-widget-container">        <a href="#ce-action=addToCart" role="button" class="elementor-button elementor-size-lg">
+            <span class="elementor-button-content-wrapper">
+                        <span class="elementor-button-icon elementor-align-icon-left" aria-hidden="true"><i class="ceicon-basket-solid"></i></span>
+                                    <span class="elementor-button-text">Add to Cart</span>
+                        </span>
+        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-65bbfaa elementor-align-justify elementor-widget__width-inherit remove_on_cfp elementor-widget elementor-widget-product-add-to-cart elementor-widget-button" data-id="65bbfaa" data-element_type="widget" data-widget_type="product-add-to-cart.default">
+        <div class="elementor-widget-container">        <a href="#ce-action=buyNow" role="button" class="elementor-button elementor-size-lg">
+            <span class="elementor-button-content-wrapper">
+                        <span class="elementor-button-icon elementor-align-icon-left" aria-hidden="true"><i class="ceicon ceicon-cart-solid"></i></span>
+                                    <span class="elementor-button-text">Buy Now</span>
+                        </span>
+        </a>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-bdb0886 elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="bdb0886" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-08ad25a ce-widgets-space--gap elementor-column elementor-col-100 elementor-top-column" data-id="08ad25a" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-ec2ea6c elementor-icon-list--layout-inline elementor-align-center elementor-mobile-align-center elementor-list-item-link-full_width elementor-widget elementor-widget-icon-list" data-id="ec2ea6c" data-element_type="widget" data-widget_type="icon-list.default">
+        <div class="elementor-widget-container">        <ul class="elementor-icon-list-items elementor-inline-items">
+                    <li class="elementor-icon-list-item">
+            <a href="#shopinstoreblock">                            <span class="elementor-icon-list-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.08163 8.17262C4.08162 8.17266 4.08163 8.17259 4.08163 8.17262L3.75959 10.6098C3.67184 11.2728 4.15339 11.7659 4.65163 11.7659H19.3475C19.8457 11.7659 20.3273 11.2729 20.2396 10.6099L19.9175 8.17262C19.9175 8.17259 19.9175 8.17266 19.9175 8.17262C19.8473 7.64189 19.4373 7.31128 19.0255 7.31128H4.97368C4.56184 7.31128 4.15189 7.64189 4.08163 8.17262ZM2.59458 7.97591C2.75399 6.77091 3.73928 5.81128 4.97368 5.81128H19.0255C20.2599 5.81128 21.2452 6.77091 21.4046 7.97591L21.7266 10.4131C21.919 11.8673 20.8575 13.2659 19.3475 13.2659H4.65163C3.14169 13.2659 2.08014 11.8675 2.27251 10.4133C2.2725 10.4133 2.27252 10.4132 2.27251 10.4133L2.59458 7.97591Z" fill="black"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M4.67969 11.7646C5.09391 11.7646 5.42969 12.1004 5.42969 12.5146V18.5646C5.42969 19.1169 5.87743 19.5641 6.42814 19.5641H17.5698C18.1212 19.5641 18.5682 19.1171 18.5682 18.5646V12.5146C18.5682 12.1004 18.904 11.7646 19.3182 11.7646C19.7324 11.7646 20.0682 12.1004 20.0682 12.5146V18.5646C20.0682 19.9445 18.9507 21.0641 17.5698 21.0641H6.42814C5.04846 21.0641 3.92969 19.9448 3.92969 18.5646V12.5146C3.92969 12.1004 4.26548 11.7646 4.67969 11.7646Z" fill="black"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M11.999 16.3774C11.2398 16.3774 10.623 16.9942 10.623 17.7534V20.3143C10.623 20.7285 10.2872 21.0643 9.87305 21.0643C9.45883 21.0643 9.12305 20.7285 9.12305 20.3143V17.7534C9.12305 16.1658 10.4114 14.8774 11.999 14.8774C13.5878 14.8774 14.875 16.166 14.875 17.7534V20.3143C14.875 20.7285 14.5392 21.0643 14.125 21.0643C13.7107 21.0643 13.375 20.7285 13.375 20.3143V17.7534C13.375 16.994 12.7589 16.3774 11.999 16.3774Z" fill="black"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M6.42814 4.43506C5.87743 4.43506 5.42969 4.88225 5.42969 5.43448V6.56022C5.42969 6.97443 5.09391 7.31022 4.67969 7.31022C4.26548 7.31022 3.92969 6.97443 3.92969 6.56022V5.43448C3.92969 4.05437 5.04846 2.93506 6.42814 2.93506H17.5698C18.9507 2.93506 20.0682 4.05464 20.0682 5.43448V6.56022C20.0682 6.97443 19.7324 7.31022 19.3182 7.31022C18.904 7.31022 18.5682 6.97443 18.5682 6.56022V5.43448C18.5682 4.88198 18.1212 4.43506 17.5698 4.43506H6.42814Z" fill="black"></path></svg></span>
+                            <span class="elementor-icon-list-text">65+ STORES</span>
+            </a>            </li>
+                    <li class="elementor-icon-list-item">
+                                        <span class="elementor-icon-list-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.1514 14.1992C13.1514 14.8994 12.6016 15.4492 11.7988 15.4492L11.4463 15.4395L11.3184 15.4341L11.2095 15.4307C11.0791 15.4272 10.9458 15.4268 10.8101 15.4302C10.7251 15.4321 10.6396 15.4355 10.5537 15.4404L10.4302 15.4492H10.1812C9.76758 15.4492 9.43115 15.7793 9.43115 16.1992L9.43262 16.2437C9.43262 16.2754 9.43555 16.3066 9.44043 16.3389C9.50049 16.749 9.88135 17.0293 10.2915 16.9692L10.3867 16.9565L10.4551 16.9492H11.8052H11.832C12.1074 16.9595 12.4009 16.9658 12.6875 16.959C13.8594 16.9395 14.8623 16.4292 15.7124 15.8389C16.1401 15.5493 16.5464 15.2192 16.9253 14.9092C17.0547 14.8052 17.1802 14.7026 17.3032 14.6021L17.3223 14.5859L17.3896 14.5312C17.603 14.3579 17.8081 14.1914 18.0132 14.0391C18.4624 13.6992 19.0903 13.749 19.4883 14.1392C19.9302 14.5894 19.9292 15.3091 19.4883 15.749L19.334 15.9038C17.7979 17.4546 16.5312 18.7339 14.6265 19.479C11.8872 20.5391 9.34326 20.0391 6.30029 19.4395C5.77881 19.3389 5.27588 19.2769 4.78125 19.2388C4.31689 19.2031 3.85938 19.1885 3.39941 19.1831C3.1792 19.1802 2.9585 19.1792 2.73633 19.1792C2.32227 19.1792 1.98633 19.519 1.98633 19.9292C1.98633 20.3491 2.32227 20.6792 2.73633 20.6792C3.91553 20.6792 4.92236 20.6992 6.0083 20.9092L6.15186 20.937C9.08398 21.5181 12.0151 22.0991 15.1704 20.8789C17.3877 20.0083 18.8643 18.5146 20.3496 17.0117L20.5503 16.8091C21.5762 15.7793 21.5752 14.1191 20.5513 13.0889C20.4404 12.9775 20.3213 12.8779 20.1968 12.79C20.1182 12.7349 20.0371 12.6846 19.9546 12.6392L19.9395 6.53906C19.9375 5.23926 19.6206 4.10889 18.8574 3.28906C18.0854 2.46924 16.9746 2.09912 15.6475 2.09912L14.0186 2.10352C13.9917 2.10059 13.9644 2.09912 13.9365 2.09912C13.9077 2.09912 13.8799 2.10107 13.8521 2.104L9.91748 2.11914H8.13916C6.81445 2.11914 5.71338 2.49902 4.95654 3.3291C4.21045 4.14893 3.91016 5.28906 3.91357 6.5791L3.92822 12.4233C3.70996 12.563 3.49609 12.7056 3.28516 12.8486C3.13916 12.9478 2.99463 13.0469 2.85156 13.1455L2.65332 13.2822L2.4707 13.4067L2.31934 13.5088C1.97559 13.7393 1.88232 14.1992 2.11328 14.5488C2.34326 14.8892 2.80957 14.979 3.15332 14.749C4.98438 13.5288 6.32324 12.4692 8.2666 12.4189C9.55957 12.3892 10.8145 12.6294 12.1313 12.959C12.7612 13.1191 13.1514 13.6094 13.1514 14.1992ZM18.4395 6.54883L18.4536 12.3223C17.9805 12.3643 17.5151 12.5347 17.1113 12.8389C16.7891 13.0835 16.4634 13.3506 16.1489 13.6074L16.1367 13.6177L15.9766 13.749C15.6016 14.0591 15.2354 14.3491 14.8633 14.5991C14.7725 14.6621 14.6826 14.7222 14.5928 14.7793C14.6313 14.5947 14.6514 14.4009 14.6514 14.1992C14.6514 12.8691 13.7354 11.8188 12.4976 11.5088C11.1416 11.1689 9.72852 10.8794 8.23047 10.9189C7.18262 10.9443 6.26416 11.209 5.42627 11.5913L5.41357 6.5791C5.41309 6.38232 5.4209 6.19824 5.43652 6.02539C5.45557 5.8125 5.48682 5.61768 5.52832 5.43896C5.63916 4.96045 5.82617 4.60156 6.06543 4.33887C6.45557 3.90918 7.09424 3.61914 8.14258 3.61914L9.16846 3.61621L9.17334 8.2793C9.17383 8.34766 9.18359 8.41553 9.20166 8.48096C9.21777 8.53906 9.24072 8.59473 9.26953 8.64697C9.30029 8.70215 9.33789 8.75342 9.38184 8.7998C9.41309 8.83252 9.44727 8.8623 9.48438 8.88916C9.6792 9.0293 9.93018 9.06885 10.1582 8.98926L11.9448 8.39648L13.7173 8.979C13.9453 9.04883 14.1963 9.00928 14.3916 8.86914C14.4888 8.79883 14.5659 8.7085 14.6187 8.60449C14.6714 8.50098 14.6997 8.38379 14.6992 8.25879L14.6899 3.60156L15.6504 3.59912C15.9365 3.59912 16.1929 3.62012 16.4224 3.66016C16.5479 3.68164 16.6655 3.7085 16.7759 3.74072C17.2085 3.8667 17.5283 4.06934 17.7622 4.31934C18.1743 4.75928 18.4375 5.46924 18.4395 6.54883ZM13.1899 3.60547L10.6685 3.6123L10.6724 7.24316L11.7075 6.89941C11.8594 6.84912 12.0234 6.84912 12.1753 6.89941L13.1973 7.22998L13.1899 3.60547Z" fill="black"></path></svg></span>
+                            <span class="elementor-icon-list-text">FREE SHIPPING</span>
+                        </li>
+                    <li class="elementor-icon-list-item">
+                                        <span class="elementor-icon-list-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.5753 9.26647C15.8682 9.55933 15.8683 10.0342 15.5754 10.3271L11.8538 14.0497C11.7131 14.1905 11.5222 14.2695 11.3232 14.2695C11.1241 14.2694 10.9333 14.1902 10.7927 14.0494L8.98683 12.2407C8.69416 11.9476 8.69454 11.4727 8.98766 11.18C9.28079 10.8874 9.75566 10.8877 10.0483 11.1809L11.3238 12.4583L14.5146 9.26662C14.8075 8.97368 15.2823 8.97362 15.5753 9.26647Z" fill="black"></path><path d="M11.9998 21.75C11.9262 21.7504 11.8531 21.7396 11.7828 21.718C11.4618 21.618 3.92676 19.265 3.92676 12.67C3.92676 10.835 3.90176 9.509 3.88476 8.537C3.84076 6.103 3.83077 5.596 4.46777 4.96C5.22277 4.206 10.9158 2.25 11.9998 2.25C13.1448 2.25 18.7648 4.187 19.5338 4.962C20.1688 5.602 20.1587 6.108 20.1147 8.544C20.0977 9.516 20.0737 10.844 20.0737 12.67C20.0737 19.264 12.5378 21.621 12.2178 21.718C12.1471 21.7394 12.0736 21.7502 11.9998 21.75ZM11.9998 3.75C9.75787 4.26042 7.58199 5.02643 5.51477 6.033C5.35477 6.193 5.34876 6.525 5.38476 8.509C5.40176 9.488 5.42676 10.823 5.42676 12.67C5.42676 17.582 10.8368 19.791 11.9998 20.208C13.1628 19.791 18.5737 17.582 18.5737 12.67C18.5737 10.827 18.5988 9.495 18.6158 8.518C18.6508 6.527 18.6447 6.195 18.4697 6.018C16.4064 5.01824 14.2357 4.25732 11.9998 3.75Z" fill="black"></path></svg></span>
+                            <span class="elementor-icon-list-text">100% AUTHENTIC</span>
+                        </li>
+                    <li class="elementor-icon-list-item">
+                                        <span class="elementor-icon-list-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.642 3C19.949 3 22.639 5.69 22.639 8.998V16.175C22.639 19.482 19.949 22.173 16.642 22.173H7.998C4.691 22.173 2 19.482 2 16.175V8.998C2 5.69 4.691 3 7.998 3H16.642ZM16.642 4.5H7.998C5.518 4.5 3.5 6.518 3.5 8.998V16.175C3.5 18.655 5.518 20.673 7.998 20.673H16.642C19.122 20.673 21.139 18.655 21.139 16.175V15.895L17.8411 15.8956C15.9441 15.8956 14.4001 14.3526 14.3991 12.4566C14.3991 10.5586 15.9431 9.0146 17.8411 9.0136L21.139 9.013V8.998C21.139 6.518 19.122 4.5 16.642 4.5ZM21.139 10.513L17.8411 10.5136C16.7701 10.5146 15.8991 11.3856 15.8991 12.4556C15.8991 13.5246 16.7711 14.3956 17.8411 14.3956L21.139 14.395V10.513ZM18.2987 11.6436C18.7127 11.6436 19.0487 11.9796 19.0487 12.3936C19.0487 12.8076 18.7127 13.1436 18.2987 13.1436H17.9867C17.5727 13.1436 17.2367 12.8076 17.2367 12.3936C17.2367 11.9796 17.5727 11.6436 17.9867 11.6436H18.2987ZM12.685 7.5381C13.099 7.5381 13.435 7.8741 13.435 8.2881C13.435 8.7021 13.099 9.0381 12.685 9.0381H7.286C6.872 9.0381 6.536 8.7021 6.536 8.2881C6.536 7.8741 6.872 7.5381 7.286 7.5381H12.685Z" fill="black"></path></svg></span>
+                            <span class="elementor-icon-list-text">EMI AVAILABLE</span>
+                        </li>
+                    <li class="elementor-icon-list-item">
+            <a href="https://www.swisstimehouse.com/return-policy">                            <span class="elementor-icon-list-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.5303 14.5303C13.8232 14.2374 13.8232 13.7626 13.5303 13.4697L11.0607 11L13.5303 8.53033C13.8232 8.23744 13.8232 7.76256 13.5303 7.46967C13.2374 7.17678 12.7626 7.17678 12.4697 7.46967L9.46967 10.4697C9.17678 10.7626 9.17678 11.2374 9.46967 11.5303L12.4697 14.5303C12.7626 14.8232 13.2374 14.8232 13.5303 14.5303Z" fill="black"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M20.75 15.9712C20.75 18.0423 19.0711 19.7212 17 19.7212H7C4.92893 19.7212 3.25 18.0423 3.25 15.9712V13.4712C3.25 13.057 3.58579 12.7212 4 12.7212C4.41421 12.7212 4.75 13.057 4.75 13.4712V15.9712C4.75 17.2138 5.75736 18.2212 7 18.2212H17C18.2426 18.2212 19.25 17.2138 19.25 15.9712V13.9712C19.25 12.7286 18.2426 11.7212 17 11.7212H10.3145C9.90024 11.7212 9.56446 11.3854 9.56446 10.9712C9.56446 10.557 9.90024 10.2212 10.3145 10.2212H17C19.0711 10.2212 20.75 11.9001 20.75 13.9712V15.9712Z" fill="black"></path></svg></span>
+                            <span class="elementor-icon-list-text">EASY EXCHANGE</span>
+            </a>            </li>
+                </ul>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-3dcd472 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="3dcd472" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-6b04f392 ce-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="6b04f392" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-1d735859 elementor-widget elementor-widget-manufacturer-image elementor-widget-image" data-id="1d735859" data-element_type="widget" data-widget_type="manufacturer-image.default">
+        <div class="elementor-widget-container"><a href="https://www.swisstimehouse.com/manufacturer/casio"><img src="https://www.swisstimehouse.com/img/m/21.jpg" alt="logo" loading="lazy"></a></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-7274343a elementor-column elementor-col-50 elementor-top-column" data-id="7274343a" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-7bc0fb2e elementor-widget elementor-widget-shortcode" data-id="7bc0fb2e" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container"><div id="featurerelatedjp">
+  <div class="featured-products my-4 ">
+
+    
+      <div class="featured-products__header d-flex align-items-center mb-3">
+        
+         <div class="title-block">
+                                <div class="title">VARIATIONS OF</div>
+                                <div class="title-description">
+                                    <a href="https://www.swisstimehouse.com/manufacturer/casio">Casio</a>
+
+                                                                            - <a href="https://www.swisstimehouse.com/products/?collection=g-shock" class="product-collection">G-SHOCK</a>
+                                    
+                                                                            - <a href="https://www.swisstimehouse.com/products/?collection=g-shock&amp;series=gm-b2100" class="product-series">GM-B2100</a>
+                                                                    </div>    
+                            </div>
+        
+        <div class="featured-products__navigation d-flex flex-grow-0 flex-shrink-0 ml-auto">
+          <div class="swiper-button-prev swiper-button-custom position-static">
+            <span class="sr-only">Previous</span>
+            <span class="material-icons">keyboard_arrow_left</span>
+          </div>
+          <div class="swiper-button-next swiper-button-custom position-static">
+            <span class="sr-only">Next</span>
+            <span class="material-icons">keyboard_arrow_right</span>
+          </div>
+        </div>
+      </div>
+    
+
+     
+    <div class="swiper product-slider py-1 my-n1" data-swiper='{&quot;speed&quot;:500,&quot;breakpoints&quot;:{&quot;320&quot;:{&quot;slidesPerView&quot;:2},&quot;768&quot;:{&quot;slidesPerView&quot;:3},&quot;992&quot;:{&quot;slidesPerView&quot;:4}}}'>
+      
+        <div class="featured-products__slider swiper-wrapper ">
+          		              			
+              	
+    <div
+          class="swiper-slide product-slider__item col-6 col-md-4 col-lg-3 slides5"
+        >
+    <article
+      class="product-miniature card js-product-miniature p-2 h-100    "
+      data-id-product="122778" data-id-product-attribute="0"
+      >
+	  <div class="thumbnail-container">
+	  
+        	
+      
+  <div class="product-miniature__thumb position-relative mb-2 ">
+    <a href="https://www.swisstimehouse.com/casio-g1638" class="product-miniature__thumb-link">
+              <img
+                     src="https://www.swisstimehouse.com/184364-home_default/casio-g1638.jpg"
+                alt="Casio G1638 -..."
+                loading="lazy"
+                data-full-size-image-url="https://www.swisstimehouse.com/184364-thickbox_default/casio-g1638.jpg"
+            width="440"
+            height="569"
+                    class="img-fluid rounded lazyload"
+          />
+      
+      
+   <!--- <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--discount">-30%</li>
+            </ul> --->
+
+
+
+                        
+        <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                                                    <li class="product-flags__flag rounded product-flags__flag--discount">-30% </li>
+            
+            </ul>
+
+    </a>
+
+    
+      <a class="quick-view product-miniature__functional-btn btn btn-light shadow rounded-circle" href="#" data-link-action="quickview">
+        <span class="material-icons product-miniature__functional-btn-icon">visibility</span>
+      </a>
+    
+
+	  
+<div class="product-miniature__actions">
+            <form class="product-miniature__form" action="https://www.swisstimehouse.com/cart?add=1&amp;id_product=122778&amp;id_product_attribute=0" method="post">
+          <input type="hidden" name="id_product" value="122778">
+          <input
+            type="hidden"
+            name="qty"
+            value="1"
+            class="form-control input-qty"
+          >
+          
+<button
+   class="btn btn-primary btn-block add-to-cart slider"
+            data-button-action="add-to-cart"
+            type="submit"
+            >
+    Add
+  <span class="btn-icons">
+    
+    <span class="icon-cart">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.4378 9.89429H2.5625" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6326 12.8843H8.35938" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.97224 6.48108C3.32547 6.48108 2.21951 7.84731 2.56248 9.89788L3.37493 14.5909C3.68547 16.2847 4.92279 16.9334 5.87144 16.9334H14.1288C15.0767 16.9334 16.314 16.2847 16.6245 14.5909L17.4378 9.89788C17.7799 7.84731 16.674 6.48108 15.0273 6.48108H4.97224Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.73288 3.06641L5.95312 6.47428" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0453 6.47587L12.2656 3.06799" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+     
+    </span>
+
+    
+    <span class="icon-plus">
+     <svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 32 32" width="20" height="20"><path d="M 16 3 C 8.832031 3 3 8.832031 3 16 C 3 23.167969 8.832031 29 16 29 C 23.167969 29 29 23.167969 29 16 C 29 8.832031 23.167969 3 16 3 Z M 16 5 C 22.085938 5 27 9.914063 27 16 C 27 22.085938 22.085938 27 16 27 C 9.914063 27 5 22.085938 5 16 C 5 9.914063 9.914063 5 16 5 Z M 15 10 L 15 15 L 10 15 L 10 17 L 15 17 L 15 22 L 17 22 L 17 17 L 22 17 L 22 15 L 17 15 L 17 10 Z"fill="white" /></svg>
+    </span>
+
+  </span>
+</button>
+      </form>
+    </div>
+    
+      
+
+    
+  </div>
+
+	
+	<div class="product_list_desc">
+
+      <div class="product-title-brand">
+             <div class="category-name">
+               
+                                                                                                                                                    - G-SHOCK
+                                  </div>
+        </div>
+     
+<div class="top2">
+        
+      <h2 class="h5 product-miniature__title mb-2">
+      <a class="text-reset" href="https://www.swisstimehouse.com/casio-g1638">Casio G1638 - GM-B2100SD-1ADR G-Shock Watch</a>
+  </h2>
+		
+      </div>
+	  
+	 <!-- <div class="top4 label">
+                        Only Few left
+                </div>  -->
+	</div> 
+ 
+
+      <div class="product-miniature__pricing text-left discounted_pricing">
+              
+        <span class="price price--regular mr-1" aria-label="Regular price">₹ 49,995</span>
+      
+      
+
+      <span class="price" aria-label="Price">₹ 34,997</span>
+<span class="emi_label">
+</span>
+      
+
+      
+    </div>
+  
+<!---
+<div class="top3">
+                    <div class="category-name">
+                G-Shock Watches
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+              </div>
+--->	
+      
+              
+</div>
+    </article>
+  </div>
+
+            
+			          		              			
+              	
+    <div
+          class="swiper-slide product-slider__item col-6 col-md-4 col-lg-3 slides5"
+        >
+    <article
+      class="product-miniature card js-product-miniature p-2 h-100    "
+      data-id-product="122629" data-id-product-attribute="0"
+      >
+	  <div class="thumbnail-container">
+	  
+        	
+      
+  <div class="product-miniature__thumb position-relative mb-2 ">
+    <a href="https://www.swisstimehouse.com/casio-g1629" class="product-miniature__thumb-link">
+              <img
+                     src="https://www.swisstimehouse.com/183881-home_default/casio-g1629.jpg"
+                alt="Casio G1629 -..."
+                loading="lazy"
+                data-full-size-image-url="https://www.swisstimehouse.com/183881-thickbox_default/casio-g1629.jpg"
+            width="440"
+            height="569"
+                    class="img-fluid rounded lazyload"
+          />
+      
+      
+   <!--- <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--discount">-30%</li>
+            </ul> --->
+
+
+
+                        
+        <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                                                    <li class="product-flags__flag rounded product-flags__flag--discount">-30% </li>
+            
+            </ul>
+
+    </a>
+
+    
+      <a class="quick-view product-miniature__functional-btn btn btn-light shadow rounded-circle" href="#" data-link-action="quickview">
+        <span class="material-icons product-miniature__functional-btn-icon">visibility</span>
+      </a>
+    
+
+	  
+<div class="product-miniature__actions">
+            <form class="product-miniature__form" action="https://www.swisstimehouse.com/cart?add=1&amp;id_product=122629&amp;id_product_attribute=0" method="post">
+          <input type="hidden" name="id_product" value="122629">
+          <input
+            type="hidden"
+            name="qty"
+            value="1"
+            class="form-control input-qty"
+          >
+          
+<button
+   class="btn btn-primary btn-block add-to-cart slider"
+            data-button-action="add-to-cart"
+            type="submit"
+            >
+    Add
+  <span class="btn-icons">
+    
+    <span class="icon-cart">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.4378 9.89429H2.5625" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6326 12.8843H8.35938" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.97224 6.48108C3.32547 6.48108 2.21951 7.84731 2.56248 9.89788L3.37493 14.5909C3.68547 16.2847 4.92279 16.9334 5.87144 16.9334H14.1288C15.0767 16.9334 16.314 16.2847 16.6245 14.5909L17.4378 9.89788C17.7799 7.84731 16.674 6.48108 15.0273 6.48108H4.97224Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.73288 3.06641L5.95312 6.47428" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0453 6.47587L12.2656 3.06799" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+     
+    </span>
+
+    
+    <span class="icon-plus">
+     <svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 32 32" width="20" height="20"><path d="M 16 3 C 8.832031 3 3 8.832031 3 16 C 3 23.167969 8.832031 29 16 29 C 23.167969 29 29 23.167969 29 16 C 29 8.832031 23.167969 3 16 3 Z M 16 5 C 22.085938 5 27 9.914063 27 16 C 27 22.085938 22.085938 27 16 27 C 9.914063 27 5 22.085938 5 16 C 5 9.914063 9.914063 5 16 5 Z M 15 10 L 15 15 L 10 15 L 10 17 L 15 17 L 15 22 L 17 22 L 17 17 L 22 17 L 22 15 L 17 15 L 17 10 Z"fill="white" /></svg>
+    </span>
+
+  </span>
+</button>
+      </form>
+    </div>
+    
+      
+
+    
+  </div>
+
+	
+	<div class="product_list_desc">
+
+      <div class="product-title-brand">
+             <div class="category-name">
+               
+                                                                                                                                                    - G-SHOCK
+                                  </div>
+        </div>
+     
+<div class="top2">
+        
+      <h2 class="h5 product-miniature__title mb-2">
+      <a class="text-reset" href="https://www.swisstimehouse.com/casio-g1629">Casio G1629 - GM-B2100AD-5ADR G-Shock Watch</a>
+  </h2>
+		
+      </div>
+	  
+	 <!-- <div class="top4 label">
+                        EMI Available
+                </div>  -->
+	</div> 
+ 
+
+      <div class="product-miniature__pricing text-left discounted_pricing">
+              
+        <span class="price price--regular mr-1" aria-label="Regular price">₹ 49,995</span>
+      
+      
+
+      <span class="price" aria-label="Price">₹ 34,997</span>
+<span class="emi_label">
+</span>
+      
+
+      
+    </div>
+  
+<!---
+<div class="top3">
+                    <div class="category-name">
+                G-Shock Watches
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+              </div>
+--->	
+      
+              
+</div>
+    </article>
+  </div>
+
+            
+			          		              			
+              	
+    <div
+          class="swiper-slide product-slider__item col-6 col-md-4 col-lg-3 slides5"
+        >
+    <article
+      class="product-miniature card js-product-miniature p-2 h-100    "
+      data-id-product="118989" data-id-product-attribute="0"
+      >
+	  <div class="thumbnail-container">
+	  
+    	
+      
+  <div class="product-miniature__thumb position-relative mb-2 ">
+    <a href="https://www.swisstimehouse.com/casio-g1563" class="product-miniature__thumb-link">
+              <img
+                     src="https://www.swisstimehouse.com/169415-home_default/casio-g1563.jpg"
+                alt="Casio G1563 -..."
+                loading="lazy"
+                data-full-size-image-url="https://www.swisstimehouse.com/169415-thickbox_default/casio-g1563.jpg"
+            width="440"
+            height="569"
+                    class="img-fluid rounded lazyload"
+          />
+      
+      
+   <!--- <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+            </ul> --->
+
+
+
+            
+        <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+            </ul>
+
+    </a>
+
+    
+      <a class="quick-view product-miniature__functional-btn btn btn-light shadow rounded-circle" href="#" data-link-action="quickview">
+        <span class="material-icons product-miniature__functional-btn-icon">visibility</span>
+      </a>
+    
+
+	  
+<div class="product-miniature__actions">
+            <form class="product-miniature__form" action="https://www.swisstimehouse.com/cart?add=1&amp;id_product=118989&amp;id_product_attribute=0" method="post">
+          <input type="hidden" name="id_product" value="118989">
+          <input
+            type="hidden"
+            name="qty"
+            value="1"
+            class="form-control input-qty"
+          >
+          
+<button
+   class="btn btn-primary btn-block add-to-cart slider"
+            data-button-action="add-to-cart"
+            type="submit"
+            >
+    Add
+  <span class="btn-icons">
+    
+    <span class="icon-cart">
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.4378 9.89429H2.5625" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6326 12.8843H8.35938" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.97224 6.48108C3.32547 6.48108 2.21951 7.84731 2.56248 9.89788L3.37493 14.5909C3.68547 16.2847 4.92279 16.9334 5.87144 16.9334H14.1288C15.0767 16.9334 16.314 16.2847 16.6245 14.5909L17.4378 9.89788C17.7799 7.84731 16.674 6.48108 15.0273 6.48108H4.97224Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.73288 3.06641L5.95312 6.47428" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0453 6.47587L12.2656 3.06799" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+     
+    </span>
+
+    
+    <span class="icon-plus">
+     <svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 32 32" width="20" height="20"><path d="M 16 3 C 8.832031 3 3 8.832031 3 16 C 3 23.167969 8.832031 29 16 29 C 23.167969 29 29 23.167969 29 16 C 29 8.832031 23.167969 3 16 3 Z M 16 5 C 22.085938 5 27 9.914063 27 16 C 27 22.085938 22.085938 27 16 27 C 9.914063 27 5 22.085938 5 16 C 5 9.914063 9.914063 5 16 5 Z M 15 10 L 15 15 L 10 15 L 10 17 L 15 17 L 15 22 L 17 22 L 17 17 L 22 17 L 22 15 L 17 15 L 17 10 Z"fill="white" /></svg>
+    </span>
+
+  </span>
+</button>
+      </form>
+    </div>
+    
+      
+
+    
+  </div>
+
+	
+	<div class="product_list_desc">
+
+      <div class="product-title-brand">
+             <div class="category-name">
+               
+                                                                                                                                                    - G-SHOCK
+                                  </div>
+        </div>
+     
+<div class="top2">
+        
+      <h2 class="h5 product-miniature__title mb-2">
+      <a class="text-reset" href="https://www.swisstimehouse.com/casio-g1563">Casio G1563 - GM-B2100AD-2ADR G-Shock Watch</a>
+  </h2>
+		
+      </div>
+	  
+	 <!-- <div class="top4 label">
+                        EMI Available
+                </div>  -->
+	</div> 
+ 
+
+      <div class="product-miniature__pricing text-left ">
+      
+      
+
+      <span class="price" aria-label="Price">₹ 49,995</span>
+<span class="emi_label">
+              EMI Available
+               </span>
+      
+
+      
+    </div>
+  
+<!---
+<div class="top3">
+                    <div class="category-name">
+                G-Shock Watches
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+              </div>
+--->	
+      
+              
+</div>
+    </article>
+  </div>
+
+            
+			          		              			
+              	
+    <div
+          class="swiper-slide product-slider__item col-6 col-md-4 col-lg-3 slides5"
+        >
+    <article
+      class="product-miniature card js-product-miniature p-2 h-100    sold_out_product"
+      data-id-product="116899" data-id-product-attribute="0"
+      >
+	  <div class="thumbnail-container">
+	  
+    	
+      
+  <div class="product-miniature__thumb position-relative mb-2 ">
+    <a href="https://www.swisstimehouse.com/casio-g1481" class="product-miniature__thumb-link">
+              <img
+                     src="https://www.swisstimehouse.com/162949-home_default/casio-g1481.jpg"
+                alt="Casio G1481 -..."
+                loading="lazy"
+                data-full-size-image-url="https://www.swisstimehouse.com/162949-thickbox_default/casio-g1481.jpg"
+            width="440"
+            height="569"
+                    class="img-fluid rounded lazyload"
+          />
+      
+      
+   <!--- <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--out_of_stock">Sold Out</li>
+            </ul> --->
+
+
+
+                        
+        <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--out_of_stock">Sold Out</li>
+
+            </ul>
+
+    </a>
+
+    
+      <a class="quick-view product-miniature__functional-btn btn btn-light shadow rounded-circle" href="#" data-link-action="quickview">
+        <span class="material-icons product-miniature__functional-btn-icon">visibility</span>
+      </a>
+    
+
+	  
+<div class="product-miniature__actions">
+            <a href="https://www.swisstimehouse.com/casio-g1481"
+           class="btn btn-secondary btn-block"
+        > View
+        </a>
+    </div>
+    
+      
+
+    
+  </div>
+
+	
+	<div class="product_list_desc">
+
+      <div class="product-title-brand">
+             <div class="category-name">
+               
+                                                                                                                                                    - G-SHOCK
+                                  </div>
+        </div>
+     
+<div class="top2">
+        
+      <h2 class="h5 product-miniature__title mb-2">
+      <a class="text-reset" href="https://www.swisstimehouse.com/casio-g1481">Casio G1481 - GM-B2100LL-1ADR G-Shock Watch</a>
+  </h2>
+		
+      </div>
+	  
+	 <!-- <div class="top4 label">
+                      Sold Out
+                </div>  -->
+	</div> 
+ 
+
+      <div class="product-miniature__pricing text-left ">
+      
+      
+
+      <span class="price" aria-label="Price">₹ 73,995</span>
+<span class="emi_label">
+            Sold Out
+               </span>
+      
+
+      
+    </div>
+  
+<!---
+<div class="top3">
+                    <div class="category-name">
+                G-Shock Watches
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+              </div>
+--->	
+      
+              
+</div>
+    </article>
+  </div>
+
+            
+			          		              			
+              	
+    <div
+          class="swiper-slide product-slider__item col-6 col-md-4 col-lg-3 slides5"
+        >
+    <article
+      class="product-miniature card js-product-miniature p-2 h-100    sold_out_product"
+      data-id-product="115796" data-id-product-attribute="0"
+      >
+	  <div class="thumbnail-container">
+	  
+    	
+      
+  <div class="product-miniature__thumb position-relative mb-2 ">
+    <a href="https://www.swisstimehouse.com/casio-g1478-gm-b2100pc-1adr-g-shock-mens-watch" class="product-miniature__thumb-link">
+              <img
+                     src="https://www.swisstimehouse.com/159560-home_default/casio-g1478-gm-b2100pc-1adr-g-shock-mens-watch.jpg"
+                alt="Casio G1478 -..."
+                loading="lazy"
+                data-full-size-image-url="https://www.swisstimehouse.com/159560-thickbox_default/casio-g1478-gm-b2100pc-1adr-g-shock-mens-watch.jpg"
+            width="440"
+            height="569"
+                    class="img-fluid rounded lazyload"
+          />
+      
+      
+   <!--- <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--out_of_stock">Sold Out</li>
+            </ul> --->
+
+
+
+                        
+        <ul class="product-flags d-flex flex-column position-absolute w-100 pe-none">
+                    <li class="product-flags__flag rounded product-flags__flag--out_of_stock">Sold Out</li>
+
+            </ul>
+
+    </a>
+
+    
+      <a class="quick-view product-miniature__functional-btn btn btn-light shadow rounded-circle" href="#" data-link-action="quickview">
+        <span class="material-icons product-miniature__functional-btn-icon">visibility</span>
+      </a>
+    
+
+	  
+<div class="product-miniature__actions">
+            <a href="https://www.swisstimehouse.com/casio-g1478-gm-b2100pc-1adr-g-shock-mens-watch"
+           class="btn btn-secondary btn-block"
+        > View
+        </a>
+    </div>
+    
+      
+
+    
+  </div>
+
+	
+	<div class="product_list_desc">
+
+      <div class="product-title-brand">
+             <div class="category-name">
+               
+                                                                                                                                                    - G-SHOCK
+                                  </div>
+        </div>
+     
+<div class="top2">
+        
+      <h2 class="h5 product-miniature__title mb-2">
+      <a class="text-reset" href="https://www.swisstimehouse.com/casio-g1478-gm-b2100pc-1adr-g-shock-mens-watch">Casio G1478 - GM-B2100PC-1ADR G-Shock Watch</a>
+  </h2>
+		
+      </div>
+	  
+	 <!-- <div class="top4 label">
+                      Sold Out
+                </div>  -->
+	</div> 
+ 
+
+      <div class="product-miniature__pricing text-left ">
+      
+      
+
+      <span class="price" aria-label="Price">₹ 38,995</span>
+<span class="emi_label">
+            Sold Out
+               </span>
+      
+
+      
+    </div>
+  
+<!---
+<div class="top3">
+                    <div class="category-name">
+                G-Shock Watches
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+              </div>
+--->	
+      
+              
+</div>
+    </article>
+  </div>
+
+            
+			          		                                </div>
+      
+    </div>
+                                <a class="view-more" href="https://www.swisstimehouse.com/products/?series=gm-b2100&amp;collection=g-shock&amp;gender=men">View More</a>
+                                
+
+
+  </div>
+
+
+</div></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-e27f1c5 elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="e27f1c5" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-c6d1c1c elementor-column elementor-col-100 elementor-top-column" data-id="c6d1c1c" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-b5bc691 productpage-insta elementor-widget elementor-widget-ps-widget-module" data-id="b5bc691" data-element_type="widget" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- ybc_instagram -->
+    <style type="text/css">
+    .ins_button_grab{
+         background: #c2002e;         color: #ffffff;         border:1px solid #c2002e;    }
+
+    .ins_button_grab:hover{
+         background: #910011;         color: #ffffff;         border-color: #910011;    }
+
+
+    .ybc_ins_product_item, .ybc_ins_product_item span {
+     background: #000000;
+     color: #ffffff;
+        }
+
+    .ybc_ins_product_item:hover, .ybc_ins_product_item:hover span,
+    .ybc_ins_popup_product_sort .ybc_ins_product_item:hover,
+    .ybc_ins_popup_product_sort .ybc_ins_product_item.actived,
+    .ybc_ins_popup_product_sort .ybc_ins_product_item.actived span,
+    .ybc_ins_popup_product_sort .ybc_ins_product_item:hover span {
+     background: #ffffff !important;
+     color: #000000 !important;
+        }
+
+
+    .ybc_ins_item .grab_button_table_cell a.ybc_instagram_fancy {
+         background: #ffffff;         color: #333333;         border:1px solid #ffffff;    }
+
+    .ybc_ins_item .grab_button_table_cell a.ybc_instagram_fancy:hover {
+         background: #ffffff;         color: #333333;         border-color:#ffffff;    }
+
+    .user_flow a{
+         background: #c2002e;         color: #ffffff;         border:1px solid #c2002e;    }
+
+    .user_flow a:hover{
+         background: #910011;         color: #ffffff;         border-color: #910011;    }
+</style>
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-326435a8 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="326435a8" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-wider">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-33cc17e8 elementor-column elementor-col-100 elementor-top-column" data-id="33cc17e8" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-60ec206a elementor-widget__width-auto elementor-mobile-align-center ce-product-meta--layout-inline elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="60ec206a" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__category" role="listitem">   <span class="ce-product-meta__label">Category</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/g-shock-watches">G-Shock Watches</a></span></span><span class="ce-product-meta__detail ce-product-meta__manufacturer" role="listitem">   <span class="ce-product-meta__label">Brand</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/manufacturer/casio">Casio</a></span></span></div></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-3f2acb6 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="3f2acb6" data-element_type="section" id="section-tabscontent120" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-17a87ee4 elementor-column elementor-col-100 elementor-top-column" data-id="17a87ee4" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <section class="elementor-element elementor-element-54925829 elementor-widget-nav-menu elementor-section-tabbed elementor-nav--align-left elementor-section-height-min-height elementor-section-boxed elementor-section-height-default elementor-section elementor-inner-section" data-id="54925829" data-element_type="section" id="tabelcontenttabs" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <nav class="elementor-nav-tabs elementor-nav--main elementor-nav--layout-vertical e--pointer-background e--animation-fade" aria-label="Tabs">
+                    <ul class="elementor-nav ce-scrollbar-x--auto" role="tablist">
+                                                            <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item elementor-item-active" id="ce-tab-95554c2" href="#ce-action=select"
+                                role="tab" aria-selected="true" aria-controls="ce-tabpanel-95554c2">
+                                                                SPECIFICATIONS                            </a>
+                        </li>
+                                                                                <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item" id="ce-tab-5e22f58d" href="#ce-action=select"
+                                role="tab" aria-selected="false" aria-controls="  tabelcontenttabscol">
+                                                                Product Description                            </a>
+                        </li>
+                                                                                <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item" id="ce-tab-5afe9fe8" href="#ce-action=select"
+                                role="tab" aria-selected="false" aria-controls="fast-shipping">
+                                                                Delivery, Shipping and Returns                            </a>
+                        </li>
+                                                                                <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item" id="ce-tab-188fed71" href="#ce-action=select"
+                                role="tab" aria-selected="false" aria-controls="customreviewtab">
+                                                                Reviews                            </a>
+                        </li>
+                                                                                <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item" id="ce-tab-6d65a978" href="#ce-action=select"
+                                role="tab" aria-selected="false" aria-controls="swiss-time-house-payment">
+                                                                Why Swiss Time house ?                            </a>
+                        </li>
+                                                                                <li class="menu-item menu-item-type-column" role="presentation">
+                            <a class="elementor-item" id="ce-tab-2ec85435" href="#ce-action=select"
+                                role="tab" aria-selected="false" aria-controls="ce-tabpanel-2ec85435">
+                                                                Frequently Asked Questions                            </a>
+                        </li>
+                                                        </ul>
+                </nav>
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-95554c2 overflowscrolltabs elementor-column elementor-inner-column elementor-col-100 elementor-active" data-id="95554c2" data-element_type="column" data-settings="{&quot;animation&quot;:&quot;none&quot;}" id="ce-tabpanel-95554c2" role="tabpanel" aria-labelledby="ce-tab-95554c2">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <section class="elementor-element elementor-element-6c1fcdc7 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-inner-section" data-id="6c1fcdc7" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-2e583760 elementor-column elementor-col-50 elementor-inner-column" data-id="2e583760" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-25c88adb elementor-widget elementor-widget-product-features elementor-widget-heading" data-id="25c88adb" data-element_type="widget" data-widget_type="product-features.default">
+        <div class="elementor-widget-container">        <table class="ce-product-features" aria-label="Product Features">
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Gender</th>
+                <td class="ce-product-features__value">Men</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Watch Type</th>
+                <td class="ce-product-features__value">Analog-Digital</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Collection</th>
+                <td class="ce-product-features__value">G-SHOCK</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">For</th>
+                <td class="ce-product-features__value">Male</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Series</th>
+                <td class="ce-product-features__value">GM-B2100</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Warranty</th>
+                <td class="ce-product-features__value">2 Year National Warranty ( 1St Year International Warranty )</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Glass Material</th>
+                <td class="ce-product-features__value">Mineral Glass</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Water Resistance (M)</th>
+                <td class="ce-product-features__value">Y</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Case Material</th>
+                <td class="ce-product-features__value">Stainless steel</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Case Shape</th>
+                <td class="ce-product-features__value">Octagonal</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Case Specificities</th>
+                <td class="ce-product-features__value">165g</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Case Size</th>
+                <td class="ce-product-features__value">49.8X44.4X12.8 mm</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Band Material</th>
+                <td class="ce-product-features__value">One-touch 3-fold clasp
+Solid Band
+Stainless Steel</td>
+            </tr>
+                    <tr class="ce-product-features__row">
+                <th class="ce-product-features__label">Features</th>
+                <td class="ce-product-features__value">Alarm (s)
+Auto Calendar
+Bluetooth
+Countdown Timer
+Hand Shift Feature
+Hourly Time Signal
+LED Light
+Neobrite Hands
+Phone Finder
+Shock Resistant
+Solar Powered
+Solid Band
+Stopwatch
+Super Illuminator
+Tough Solar
+Water Resistance
+World Time</td>
+            </tr>
+                </table>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-c15648 elementor-hidden-phone elementor-column elementor-col-50 elementor-inner-column" data-id="c15648" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-122d81ac elementor-widget__width-initial elementor-widget elementor-widget-product-image elementor-widget-image" data-id="122d81ac" data-element_type="widget" data-widget_type="product-image.default">
+        <div class="elementor-widget-container">        <div class="ce-product-image elementor-image">
+                            <img width="452" height="584" src="https://www.swisstimehouse.com/196159-medium_default/casio-g1714.jpg" alt="Casio G1714 - GM-B2100SD-1CDR G-Shock Watch" srcset="https://www.swisstimehouse.com/196159-medium_default/casio-g1714.jpg 452w, https://www.swisstimehouse.com/196159-large_default/casio-g1714.jpg 419w, https://www.swisstimehouse.com/196159-thickbox_default/casio-g1714.jpg 1100w" sizes="(max-width: 452px) 100vw, 452px">
+                        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-5e22f58d overflowscrolltabs elementor-column elementor-inner-column elementor-col-100" data-id="5e22f58d" data-element_type="column" id="tabelcontenttabscol" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}" role="tabpanel" aria-labelledby="ce-tab-5e22f58d">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-364f7f45 ce-product-meta--layout-table elementor-align-left elementor-widget elementor-widget-product-meta elementor-overflow-hidden" data-id="364f7f45" data-element_type="widget" data-widget_type="product-meta.default">
+        <div class="elementor-widget-container"><div class="ce-product-meta" role="list"><span class="ce-product-meta__detail ce-product-meta__category" role="listitem">   <span class="ce-product-meta__label">Category</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/g-shock-watches">G-Shock Watches</a></span></span><span class="ce-product-meta__detail ce-product-meta__manufacturer" role="listitem">   <span class="ce-product-meta__label">Brand</span>   <span class="ce-product-meta__value"><a href="https://www.swisstimehouse.com/manufacturer/casio">Casio</a></span></span><span class="ce-product-meta__detail ce-product-meta__reference" role="listitem">   <span class="ce-product-meta__label">Reference</span>   <span class="ce-product-meta__value">G1714</span></span></div></div>        </div>
+                <div class="elementor-element elementor-element-633ad7c0 elementor-widget elementor-widget-product-description elementor-widget-text-editor" data-id="633ad7c0" data-element_type="widget" data-widget_type="product-description.default">
+        <div class="elementor-widget-container">###############################################################################################################################################################################################################################################################</div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-5afe9fe8 overflowscrolltabs elementor-column elementor-inner-column elementor-col-100" data-id="5afe9fe8" data-element_type="column" id="fast-shipping" role="tabpanel" aria-labelledby="ce-tab-5afe9fe8">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-181e76e2 elementor-widget elementor-widget-text-editor" data-id="181e76e2" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><h3>Shipping and Delivery</h3><p></p><p><strong>Standard Delivery</strong><br />Free Delivery on all orders over Rs.1000. Delivered within 2 - 6 days.<br /><br /><strong>In Store Pickup</strong><br />Choose in-store pickup and experiece unparalleled in-store shopping experience.</p><p><br /><strong>International Delivery </strong><br />We ship products worldwide. We do not deliver the following brands outside India - Rolex, Tudor, Omega, Longines, Rado and Tissot.<br /><br /></p><p><strong>Safe Delivery </strong><br />All orders are safely packed and fully insured, ensuring that you receive your items in perfect condition.</p><h3>Exchanges and returns</h3><p></p><p></p><p><strong>Return Policy</strong><br />You have 7 days from the delivery date to return your purchase from our webshop.</p><p><strong>Returns to a store</strong><br />All items can be returned/exchanged as well to our offline stores.</p><p></p><p><em>For more information, we suggest you visit the <a href="https://www.swisstimehouse.com/contact-us"><span style="text-decoration: underline;">Help</span></a> section.</em></p></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-188fed71 overflowscrolltabs elementor-column elementor-inner-column elementor-col-100" data-id="188fed71" data-element_type="column" id="customreviewtab" data-settings="{&quot;animation&quot;:&quot;none&quot;}" role="tabpanel" aria-labelledby="ce-tab-188fed71">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-204877b elementor-widget elementor-widget-shortcode" data-id="204877b" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container">
+
+
+
+    
+
+
+        <div id="idTab777" style="max-height:100%" class="block-categories tab-pane fade1 in">
+            
+                <style type="text/css">
+                    #idTab777.tab-pane{max-height:100%!important}
+
+                </style>
+            
+
+            <!-- reviews template -->
+
+            <div id="shopify-product-reviews">
+
+                <div class="spr-container row-custom">
+
+
+
+
+                                            <div class="text-align-center margin-bottom-20">
+                            <span class="spr-summary-actions">
+
+                              <a class="btn-spmgsnipreview btn-primary-spmgsnipreview" href="javascript:void(0)"  onclick="show_form_review(1)">
+                                <span>
+                                    <i class="icon-pencil"></i>
+                                    Write a Review
+                                </span>
+                              </a>
+
+                            </span>
+                        </div>
+                    
+
+                    <div class="spr-content col-sm-12-custom" id="spr-content">
+
+
+
+
+                        
+                        <script type="text/javascript">
+                            var spmgsnipreview_module_dir = '/modules/spmgsnipreview/';
+                            var spmgsnipreview_star_active = 'star-active-yellow.png';
+                            var spmgsnipreview_star_noactive = 'star-noactive-yellow.png';
+                            var spmgsnipreview_star_half_active = 'star-half-active-yellow.png';
+
+                            var spmgsnipreview_min_star_par = '0.2';
+                            var spmgsnipreview_max_star_par = '0.8';
+                        </script>
+                        
+
+
+
+                        
+                        <script type="text/javascript">
+                            document.addEventListener("DOMContentLoaded", function(event) {                                 jQuery(document).ready(init_rating);
+
+                                $("#idTab777-my-click").click(function() {
+                                    $('.total-info-tool-product-page .btn-spmgsnipreview').parent().hide();
+                                });
+
+                                }); 
+
+
+
+
+
+                        </script>
+                        
+
+
+                        <div id="add-review-block" style="display: none">
+                            
+                            
+
+                            
+
+
+                                                                                            <div class="advertise-text-review">
+                                <span>
+                                    <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-active-yellow.png"
+                                         alt="Write a review and get voucher for discount" />
+                                    Write a review and get voucher for discount
+                                    <b>2 %</b>                                                                         ,
+                                    valid for 180 days
+                                </span>
+                                </div>
+                            
+
+                                                        <br/>
+                                <div class="advertise-text-review" id="facebook-share-review-block">
+                                <span>
+                                    <img width="16" height="16" src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/btn/ico-facebook.png"
+                                         alt="Share your review on Facebook and get voucher for discount"/>
+                                    Share your review on Facebook and get voucher for discount
+                                    <b>1 %</b> 
+                                    
+                                    ,
+                                    valid for 180 days
+                                </span>
+                                </div>
+                                                            
+
+
+                                                                                    
+
+
+
+
+                                                                <div id="add-review-form-review">
+                                    <form method="post" action="https://www.swisstimehouse.com/module/spmgsnipreview/upload?token=21bb8423bb5d1270727450c8de563c7e0fee40e3" enctype="multipart/form-data"
+                                          id="add_review_item_form" name="add_review_item_form">
+
+                                        
+                                        <input type="hidden" name="action" value="add" />
+                                        <input type="hidden" name="id_product" id="id_product_spmgsnipreview" value="125701" />
+                                        <input type="hidden" name="id_category_spmgsnipreview" id="id_category_spmgsnipreview" value="281" />
+                                        <input type="hidden" name="id_customer" value="0" />
+
+
+                                        <div class="title-rev">
+                                            <div class="title-form-text-left">
+                                                <b>Write Your Review</b>
+                                            </div>
+
+                                            <input type="button" value="close" class="btn-spmgsnipreview btn-primary-spmgsnipreview title-form-text-right" onclick="show_form_review(0)">
+                                            <div class="clear-spmgsnipreview"></div>
+                                        </div>
+
+                                        <div id="body-add-review-form-review">
+
+
+                                            
+                                                
+                                                    
+                                                        <label for="rat_rel1"
+                                                               class="float-left">Total Rating<sup class="required">*</sup></label>
+
+                                                        <div class="rat rating-stars-dynamic">
+                                                        <span onmouseout="read_rating_review_shop('rat_rel1');">
+
+                                                            <img  onmouseover="_rating_efect_rev(1,0,'rat_rel1')"
+                                                                  onmouseout="_rating_efect_rev(1,1,'rat_rel1')"
+                                                                  onclick = "rating_review_shop('rat_rel1',1); rating_checked1=true; "
+                                                                  src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                                                  alt="1" id="img_rat_rel1_1" />
+
+                                                            <img  onmouseover="_rating_efect_rev(2,0,'rat_rel1')"
+                                                                  onmouseout="_rating_efect_rev(2,1,'rat_rel1')"
+                                                                  onclick = "rating_review_shop('rat_rel1',2); rating_checked1=true;"
+                                                                  src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                                                  alt="2" id="img_rat_rel1_2" />
+
+                                                            <img  onmouseover="_rating_efect_rev(3,0,'rat_rel1')"
+                                                                  onmouseout="_rating_efect_rev(3,1,'rat_rel1')"
+                                                                  onclick = "rating_review_shop('rat_rel1',3); rating_checked1=true;"
+                                                                  src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                                                  alt="3"  id="img_rat_rel1_3" />
+                                                            <img  onmouseover="_rating_efect_rev(4,0,'rat_rel1')"
+                                                                  onmouseout="_rating_efect_rev(4,1,'rat_rel1')"
+                                                                  onclick = "rating_review_shop('rat_rel1',4); rating_checked1=true;"
+                                                                  src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                                                  alt="4"  id="img_rat_rel1_4" />
+                                                            <img  onmouseover="_rating_efect_rev(5,0,'rat_rel1')"
+                                                                  onmouseout="_rating_efect_rev(5,1,'rat_rel1')"
+                                                                  onclick = "rating_review_shop('rat_rel1',5); rating_checked1=true;"
+                                                                  src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                                                  alt="5"  id="img_rat_rel1_5" />
+                                                        </span>
+                                                                                                                    </div>
+                                                        <input type="hidden" id="rat_rel1" name="rat_rel1" value="0"/>
+                                                        <div class="clr"></div>
+                                                        <div class="errorTxtAdd" id="error_rat_rel1"></div>
+
+                                                                                                                                                											<div class="crow">
+											<div class="ccolumn">
+												<label for="name-review">Name<sup class="required">*</sup></label>
+												<input type="text" name="name-review" id="name-review" value=""  onkeyup="check_inpNameReview();" onblur="check_inpNameReview();" />
+												<div class="errorTxtAdd" id="error_name-review"></div>
+											</div>
+											<div class="ccolumn">
+
+												<label for="email-review">Email<sup class="required">*</sup></label>
+												<input type="text" name="email-review" id="email-review" value="" onkeyup="check_inpEmailReview();" onblur="check_inpEmailReview();"  />
+												<div id="error_email-review" class="errorTxtAdd"></div>
+											</div>
+											</div>
+											<div class="crow">
+											<div class="ccolumn">
+
+                                                                                            <label for="avatar-review">Avatar</label>
+
+                                                
+                                                <input type="file" name="avatar-review"
+                                                       id="avatar-review"
+                                                       class="testimonials-input"
+                                                        />
+                                                <div class="avatar-guid">
+                                                    Allow formats: *.jpg; *.jpeg; *.png; *.gif.
+                                                </div>
+                                                <div class="errorTxtAdd" id="error_avatar-review"></div>
+
+                                                                                                                                                                                            											</div>
+											<div class="ccolumn">
+											                                                <label for="text-files">Files</label>
+                                                <span class="file-upload-rev" id="file-upload-rev">
+                                            <input type="file" name="files[]" multiple />
+                                            <div class="progress-files-bar">
+                                                <div class="progress-files"></div>
+                                            </div>
+                                            <div id="file-files-list"></div>
+                                        </span>
+
+
+                                                <div class="avatar-guid">
+                                                    Maximum files to upload - <b>5</b><br/> Allow formats: *.jpg; *.jpeg; *.png; *.gif.
+                                                </div>
+                                                <div id="error_text-files" class="errorTxtAdd"></div>
+
+
+                                                                                                                                                                                            											</div>
+											</div>
+                                            
+                                                                                            <label for="text-review">Text<sup class="required">*</sup></label>
+                                                <textarea id="text-review" name="text-review" cols="42" rows="7" onkeyup="check_inpTextReview();" onblur="check_inpTextReview();"></textarea>
+                                                <div id="textarea_feedback"></div>
+                                                <div id="error_text-review" class="errorTxtAdd"></div>
+                                            
+
+                                           
+
+
+                                                                                        
+                                            
+                                            
+
+
+                                        </div>
+
+                                        <div id="footer-add-review-form-review">
+                                            <button type="submit" value="Add review" class="btn btn-success">Add review</button>
+                                            &nbsp;
+                                            <button onclick="show_form_review(0)" value="Cancel" class="btn btn-danger">Cancel</button>
+                                        </div>
+
+
+
+
+
+
+
+                                    </form>
+                                </div>
+
+
+                            
+                                <script type="text/javascript">
+
+
+
+
+
+                                    function field_gdpr_change_spmgsnipreview(){
+                                        // gdpr
+                                        var gdpr_spmgsnipreview = $('#psgdpr_consent_checkbox_244');
+
+                                        var is_gdpr_spmgsnipreview = 1;
+
+                                        if(gdpr_spmgsnipreview.length>0){
+
+                                            if(gdpr_spmgsnipreview.prop('checked') == true) {
+                                                $('.gdpr_module_244 .psgdpr_consent_message').removeClass('error-label');
+                                            } else {
+                                                $('.gdpr_module_244 .psgdpr_consent_message').addClass('error-label');
+                                                is_gdpr_spmgsnipreview = 0;
+                                            }
+
+                                            $('#psgdpr_consent_checkbox_244').on('click', function(){
+                                                if(gdpr_spmgsnipreview.prop('checked') == true) {
+                                                    $('.gdpr_module_244 .psgdpr_consent_message').removeClass('error-label');
+                                                } else {
+                                                    $('.gdpr_module_244 .psgdpr_consent_message').addClass('error-label');
+                                                }
+                                            });
+
+                                        }
+
+                                        //gdpr
+
+                                        return is_gdpr_spmgsnipreview;
+                                    }
+                                    
+
+                                                                        var baseDir = 'https://www.swisstimehouse.com/';
+                                    
+                                    var spmgsnipreviewis_captcha = 0;
+                                    var spmgsnipreviewprcaptcha_type = 2;
+
+
+
+                                    
+                                    var file_upload_url_spmgsnipreview = 'https://www.swisstimehouse.com/module/spmgsnipreview/upload?token=21bb8423bb5d1270727450c8de563c7e0fee40e3';
+                                    var file_max_files_spmgsnipreview = 5;
+                                    var file_max_message_spmgsnipreview = 'You can upload a maximum of '+file_max_files_spmgsnipreview+' files';
+                                    var file_path_upload_url_spmgsnipreview = baseDir + 'upload/spmgsnipreview/tmp/';
+
+                                    
+
+                                    var text_min = 5;
+
+                                    document.addEventListener("DOMContentLoaded", function(event) {                                         $(document).ready(function(){
+
+                                            // gdpr
+                                            setTimeout(function() {
+                                                $('#footer-add-review-form-review').find('button[type="submit"]').removeAttr('disabled');
+                                            }, 1000);
+                                            // gdpr
+
+                                            if(0 > 0){
+                                                $('input#name-review').val('');
+                                                $('input#email-review').val('');
+                                                init_review_spm();
+                                            }
+
+
+
+                                                                                        $('#textarea_feedback').html($('#text-review').val().length + ' chars. Min '+text_min+' chars');
+
+                                            $('#text-review').keyup(function() {
+                                                var text_length_val = trim(document.getElementById('text-review').value);
+                                                var text_length = text_length_val.length;
+
+                                                if(text_length<text_min)
+                                                    $('#textarea_feedback').css('color','red');
+                                                else
+                                                    $('#textarea_feedback').css('color','green');
+
+                                                $('#textarea_feedback').html(text_length + ' chars. Min '+text_min+' chars');
+                                            });
+
+                                            
+                                            /* clear form fields */
+
+                                            
+                                            
+                                            
+                                            $('#rat_rel1').val(0);
+
+                                            
+                                            
+                                            
+                                                                                        $('#name-review').val('');
+                                            $('#email-review').val('');
+                                            
+                                                                                                                                    $('#text-review').val('');
+                                                                                        
+                                            /* clear form fields */
+                                        });
+
+                                        }); 
+
+
+
+                                    
+
+                                                                        function check_inpTextReview()
+                                    {
+
+                                        var text_review = trim(document.getElementById('text-review').value);
+
+                                        if (text_review.length == 0 || text_review.length<text_min)
+                                        {
+                                            field_state_change('text-review','failed', 'Please, enter the text');
+                                            return false;
+                                        }
+                                        field_state_change('text-review','success', '');
+                                        return true;
+                                    }
+                                    
+
+                                    function check_inpNameReview()
+                                    {
+
+                                        var name_review = trim(document.getElementById('name-review').value);
+
+                                        if (name_review.length == 0)
+                                        {
+                                            field_state_change('name-review','failed', 'Please, enter the name');
+                                            return false;
+                                        }
+                                        field_state_change('name-review','success', '');
+                                        return true;
+                                    }
+
+
+                                    function check_inpEmailReview()
+                                    {
+
+                                        var email_review = trim(document.getElementById('email-review').value);
+
+                                        if (email_review.length == 0)
+                                        {
+                                            field_state_change('email-review','failed', 'Please, enter the email');
+                                            return false;
+                                        }
+                                        field_state_change('email-review','success', '');
+                                        return true;
+                                    }
+
+
+                                    
+
+
+
+
+                                    
+
+
+                                    
+                                    
+                                    var rating_checked1 = false;
+
+                                    
+                                    
+
+
+
+
+                                    
+
+
+                                    
+                                    function check_inpRatingReview1()
+                                    {
+
+                                        if(!rating_checked1){
+                                            field_state_change('rat_rel1','failed', 'Please, choose the rating for Total Rating');
+                                            return false;
+                                        }
+                                        field_state_change('rat_rel1','success', '');
+                                        return true;
+
+
+                                    }
+                                    
+                                    
+                                    
+
+                                    document.addEventListener("DOMContentLoaded", function(event) {                                         $(document).ready(function (e) {
+                                            $("#add_review_item_form").on('submit',(function(e) {
+
+
+
+                                                                                                field_state_change('avatar-review','success', '');
+                                                
+
+
+
+                                                                                                
+                                                
+                                                var is_rating1 = check_inpRatingReview1();
+
+                                                
+                                                                                                
+                                                
+                                                var is_name = check_inpNameReview();
+                                                var is_email = check_inpEmailReview();
+
+                                                                                                var is_text =  check_inpTextReview();
+                                                                                                
+
+                                                // gdpr
+                                                var is_gdpr_spmgsnipreview = field_gdpr_change_spmgsnipreview();
+
+
+
+
+                                                if(is_gdpr_spmgsnipreview && //gdpr
+                                                                                                                
+                                                        
+                                                is_rating1 &&
+
+                                                
+                                                                                                
+                                                                                                is_name &&
+                                                is_email &&
+                                                                                                is_text &&
+                                                                                                                                                true
+                                                ){
+
+                                                    $('#reviews-list').css('opacity',0.5);
+                                                    $('#add-review-form-review').css('opacity',0.5);
+                                                    $('#footer-add-review-form-review button').attr('disabled','disabled');
+
+                                                    e.preventDefault();
+                                                    $.ajax({
+                                                        url: 'https://www.swisstimehouse.com/module/spmgsnipreview/ajaxreviews?token=21bb8423bb5d1270727450c8de563c7e0fee40e3',
+                                                        type: "POST",
+                                                        data:  new FormData(this),
+                                                        contentType: false,
+                                                        cache: false,
+                                                        processData:false,
+                                                        dataType: 'json',
+                                                        success: function(data)
+                                                        {
+
+
+                                                            $('#reviews-list').css('opacity',1);
+                                                            $('#add-review-form-review').css('opacity',1);
+
+                                                            if (data.status == 'success') {
+
+
+
+
+                                                                $('#gsniprev-list').html('');
+                                                                var paging = $('#gsniprev-list').prepend(data.params.content);
+                                                                $(paging).hide();
+                                                                $(paging).fadeIn('slow');
+
+                                                                $('#gsniprev-nav').html('');
+                                                                var paging = $('#gsniprev-nav').prepend(data.params.paging);
+                                                                $(paging).hide();
+                                                                $(paging).fadeIn('slow');
+
+
+                                                                var count_review = data.params.count_reviews;
+
+                                                                $('#count-review-tab').html('');
+                                                                $('#count-review-tab').html('('+count_review+')');
+
+
+
+
+
+                                                                
+                                                                jQuery(document).ready(init_rating);
+
+
+
+                                                                $('.advertise-text-review').css('opacity','0.2');
+                                                                $('#add-review-block').css('opacity','0.2');
+
+
+
+
+
+                                                                var voucher_html_suggestion = data.params.voucher_html_suggestion;
+
+
+
+                                                                                                                                var voucher_suggest_html = data.params.voucher_suggest_html;
+                                                                showVoucherSuggest(voucher_suggest_html);
+
+                                                                
+
+
+                                                            } else {
+
+                                                                var error_type = data.params.error_type;
+                                                                $('#footer-add-review-form-review button').removeAttr('disabled');
+
+
+                                                                
+                                                                if(error_type == 2){
+                                                                    field_state_change('email-review','failed', 'Please enter a valid email address. For example johndoe@domain.com.');
+                                                                    field_state_change('inpCaptchaReview','failed', 'Please, enter the security code');
+
+                                                                    
+                                                                    return false;
+                                                                }
+
+                                                                if(error_type == 1){
+                                                                    alert("You have already add review for this product");
+                                                                    window.location.reload();
+                                                                }
+
+                                                                if(error_type == 8){
+                                                                    field_state_change('avatar-review','failed', 'Invalid file type, please try again!');
+                                                                    return false;
+                                                                } else if(error_type == 9){
+                                                                    field_state_change('avatar-review','failed', 'Wrong file format, please try again!');
+                                                                    return false;
+                                                                } else if(error_type == 10){
+                                                                    field_state_change('email-review','failed', 'Only customers that have purchased a product can give a review!');
+                                                                    field_state_change('name-review','failed', 'Only customers that have purchased a product can give a review!');
+                                                                    return false;
+                                                                }
+
+                                                                
+
+                                                            }
+
+                                                        }
+                                                    });
+
+
+
+
+
+                                                } else {
+                                                    return false;
+                                                }
+
+                                            }));
+
+                                        });
+                                        }); 
+
+
+                                    //}
+
+
+                                    function showSocialSuggestion(voucher_html){
+                                                                                if ($('div#fb-con-wrapper').length == 0)
+                                        {
+                                            conwrapper = '<div id="fb-con-wrapper"><\/div>';
+                                            $('body').append(conwrapper);
+                                        } else {
+                                            $('#fb-con-wrapper').html('');
+                                        }
+
+                                        if ($('div#fb-con').length == 0)
+                                        {
+                                            condom = '<div id="fb-con"><\/div>';
+                                            $('body').append(condom);
+                                        }
+
+                                        $('div#fb-con').fadeIn(function(){
+
+                                            $(this).css('filter', 'alpha(opacity=70)');
+                                            $(this).bind('click dblclick', function(){
+                                                $('div#fb-con-wrapper').hide();
+                                                $(this).fadeOut();
+                                                window.location.reload();
+                                            });
+                                        });
+
+                                        $('div#fb-con-wrapper').html('<a id="button-close" style="display: inline;"><\/a>'+voucher_html).fadeIn();
+
+                                        $("a#button-close").click(function() {
+                                            $('div#fb-con-wrapper').hide();
+                                            $('div#fb-con').fadeOut();
+                                            window.location.reload();
+                                        });
+                                                                            }
+
+                                    function showVoucherSuggest(voucher_html){
+                                        if ($('div#fb-con-wrapper').length == 0)
+                                        {
+                                            conwrapper = '<div id="fb-con-wrapper"><\/div>';
+                                            $('body').append(conwrapper);
+                                        } else {
+                                            $('#fb-con-wrapper').html('');
+                                        }
+
+                                        if ($('div#fb-con').length == 0)
+                                        {
+                                            condom = '<div id="fb-con"><\/div>';
+                                            $('body').append(condom);
+                                        }
+
+                                        $('div#fb-con').fadeIn(function(){
+
+                                            $(this).css('filter', 'alpha(opacity=70)');
+                                            $(this).bind('click dblclick', function(){
+                                                $('div#fb-con-wrapper').hide();
+                                                $(this).fadeOut();
+                                                window.location.reload();
+                                            });
+                                        });
+
+                                        $('div#fb-con-wrapper').html('<a id="button-close" style="display: inline;"><\/a>'+voucher_html).fadeIn();
+
+                                        $("a#button-close").click(function() {
+                                            $('div#fb-con-wrapper').hide();
+                                            $('div#fb-con').fadeOut();
+                                            window.location.reload();
+                                        });
+
+                                    }
+
+
+                                </script>
+                            
+
+                            
+
+
+                            
+                        </div>
+
+
+
+
+
+
+
+
+                        <div class="row-custom total-info-tool-product-page">
+                            <div class="col-sm-5-custom first-block-ti">
+
+
+
+                                
+
+                 <span class="spr-starrating spr-summary-starrating">
+
+                                    
+
+                                                                            
+
+                                    <b class="spr-summary-actions-togglereviews gsniprev-block-ratings-text">
+                                                                                                                                                                                                        Based on <span class="font-weight-bold">0</span> reviews
+                                    </b>
+
+
+
+                    -
+
+                    <span>
+                                            
+                                                              <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                       alt="0"/>
+                                                                                
+                                                              <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                       alt="1"/>
+                                                                                
+                                                              <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                       alt="2"/>
+                                                                                
+                                                              <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                       alt="3"/>
+                                                                                
+                                                              <img src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/img/star-noactive-yellow.png"
+                                       alt="4"/>
+                                                                                                    </span>
+
+                    <span class="gsniprev-block-ratings-text">
+                                                                                                
+                        <span>0</span>/<span >5</span>
+                    </span>
+
+                    
+                </span>
+
+
+
+
+
+                            </div>
+                                                        <div class="col-sm-6-custom b-search-items">
+
+                                <form onsubmit="return false;" method="post" action="#">
+
+                                    <fieldset>
+                                        <input type="submit" value="go" class="button_mini_custom" onclick="go_page_spmgsnipreviewr(0,'productpagereviews','',1,125701)">
+                                        <input type="text" class="txt" name="searchr" id="searchr"
+                                               onfocus="if(this.value == 'Search') {this.value='';};"
+                                               onblur="if(this.value == '') {this.value='Search';};"
+                                               value="Search" />
+
+                                        <a rel="nofollow" href="javascript:void(0)" id="clear-search-reviews" class="clear-search-items display-none"
+                                           onclick="go_page_spmgsnipreviewr(0,'productpagereviews','','',125701)"
+                                                >
+                                            Clear search
+                                        </a>
+
+
+                                    </fieldset>
+                                </form>
+
+
+                            </div>
+                            
+                        </div>
+
+
+
+
+
+                        
+                        
+
+                        
+
+
+
+                        
+
+                            <div class="advertise-text-review advertise-text-review-text-align" id="no-customers-reviews">
+                                No reviews for the product
+
+                                                                    <br/><br/>
+                                    <a href="javascript:void(0)" class="btn-spmgsnipreview btn-primary-spmgsnipreview" onclick="show_form_review(1)">
+                                        <b id="button-addreview-blockreview">
+                                            <i class="icon-pencil"></i>&nbsp;Be the first to write your review !
+                                        </b>
+                                    </a>
+                                                            </div>
+
+
+
+
+                        
+                    </div>
+
+                </div></div>
+
+            <div class="clear-spmgsnipreview"></div>
+            <!-- reviews template -->
+
+
+
+        </div>
+
+
+
+    
+
+
+
+
+
+
+
+
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-6d65a978 overflowscrolltabs elementor-column elementor-inner-column elementor-col-100" data-id="6d65a978" data-element_type="column" id="swiss-time-house-payment" data-settings="{&quot;animation&quot;:&quot;none&quot;}" role="tabpanel" aria-labelledby="ce-tab-6d65a978">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-5c272e4 elementor-widget elementor-widget-text-editor" data-id="5c272e4" data-element_type="widget" data-settings="{&quot;_animation&quot;:&quot;none&quot;}" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">Swiss Time House unlike other e-commerce websites is not a marketplace. On other e-commerce websites, any one can register as a seller and hence they may NOT necesssarily be an authorized retailer and your risk of buying a fake or a refurbished watch is very high. Nearly 40% of the watches sold on these e-commerce sites are fake.</li></ul><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">We are the Authorized Retailer for all the brands listed on our website and all products we sell are covered by manufacturer's warranty. We have <a href="https://www.swisstimehouse.com/our-stores" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">50+<span style="box-sizing: border-box; color: #d0121a;"><span style="box-sizing: border-box;"> stores</span></span></a> across India and a very professional team to assist you at all times. We have a very rich heritage of over 78 years into retail of watches and this makes us the best place to buy your watch. </li></ul><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">Most of the purchases made through other marketplaces and e-commerce sites comes with a warranty card that is not stamped by an authorized retailer, which makes the warranty of the product void. These products will not be accepted at any Authorized Service centres for repairs.</li></ul><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">We have a very strong aftersales department. You can get in touch with us anytime for any kind of support.</li></ul><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">You can easily verify our genuinity by visiting any Brand websites and finding us under Authroised retailer/Store list.</li></ul><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><ul style="box-sizing: border-box; margin-bottom: 0px; margin-top: 0px; list-style-position: initial; list-style-image: initial; padding: 0.6rem 0.6rem 0.6rem 2rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><li style="box-sizing: border-box; text-align: justify;">Read more <span style="box-sizing: border-box; color: #d0121a;"><a href="https://www.swisstimehouse.com/about-us" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;"><span style="box-sizing: border-box; color: #d0121a;">about us</span></a></span> here.</li></ul></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-2ec85435 overflowscrolltabs elementor-column elementor-inner-column elementor-col-100" data-id="2ec85435" data-element_type="column" data-settings="{&quot;animation&quot;:&quot;none&quot;}" id="ce-tabpanel-2ec85435" role="tabpanel" aria-labelledby="ce-tab-2ec85435">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-e5a5b68 elementor-widget elementor-widget-text-editor" data-id="e5a5b68" data-element_type="widget" data-settings="{&quot;_animation&quot;:&quot;none&quot;}" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Will I get Genuine Products from www.swisstimehouse.com?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Yes, we are the Authorized dealers for all the products we sell. We have a network of<a href="https://www.swisstimehouse.com/content/our-stores" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;"> 50+ Stores</a>, including brand showrooms, which displays and sells watches and related accessories. We are committed to sell only 100% Genuine and Authentic Products on <a href="https://www.swisstimehouse.com/admin3777/www.swisstimehouse.com" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">www.swisstimehouse.com</a></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Do I get Warranty for Products purchased from www.swisstimehouse.com?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">All Products sold at www.swisstimehouse.com comes with standard Manufacturer Warranty and can be serviced at any Authorised company service centre near you free of cost within the warranty period.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Who is the preferred courier partner and how much time it takes to deliver my orders?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">We deliver products worldwide. Bluedart, DHL, Fedex, Delhivery and DTDC are our preferred courier partners and generally it takes between 1 to 5 days for delivery within India and for international orders the delivery may take upto 20 days.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">I have placed an order, when will my order be shipped?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Once you have placed your order, your order will be shipped within the next 24 to 48 hours.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">What will I do if i receive a defective product? What is your return/exchange policy?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Being a specialist in our business, we ensure you receive the product in the best condition with no defects. In case there is a manufacturing defect, then the product will be replaced. In case you do not like the product and need an exchange you can raise a request <a href="https://www.swisstimehouse.com/module/returnmanager/manager" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">here</a>. For more details, please refer our return policy <a href="https://www.swisstimehouse.com/return-policy" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">here</a>.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">How do I track my order once it is placed?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">You will receive an order confirmation on the registered email address provided once you place an order. As soon as the order is shipped, you will receive another email with the tracking details. You can also log into your account and view the status of your order under the Order history and details tab.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">What payment options are available?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Currently the following payment options are enabled.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Credit and Debit Cards (Visa / Master/ Amex)</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Net Banking across Banks</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         EMI Options – Currently Emi option is available from HDFC, ICICI, Axis, Kotak, Citi, BOB, HSBC, Ratnakar, Standard Chartered and Yes Bank</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         UPI Payments</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Wallet Payments – Paytm, PhonePe, BHIM UPI, FreeCharge, OlaMoney, Airtel Money, Jio Money, HDFC PayZapp and Yes Pay Wallets</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Cash On Delivery on Selected Brands for orders between Rs.3000 and Rs.10000</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Bajaj Finance</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">·         Swiss Pay</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Is there a charge for delivery?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">No, there are no extra charges for delivery within India. For orders outside India, Rs.2800 ($35) would be charged for all orders, which will be shown to you once you add the product to your cart. Also for international orders, any other applicable taxes such as customs duty charges are to be borne by the customer.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Can I change my order once it has been placed?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">We don't accept changes in the order once they are shipped. However If changes are communicated within 24 hours, we might be able to make the change in the order or the address of delivery. These changes are at the sole discretion of Swiss Time House.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">How can I cancel my orders?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Orders can be cancelled before they are shipped. You can place a request for cancellation in the <a href="https://www.swisstimehouse.com/module/returnmanager/manager" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">Returns Manager</a> tab under your Accounts page. For cancellations requests made after your order has been shipped, the courier charges would be deducted from your refund amount to be processed.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">When and how will I get my refund in case of cancellation or product return?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Refunds are credited back to the same account from which payments are made. The process generally takes 2-7 working days depending on the bank and the gateway. www.swisstimehouse.com does not have influence on the time lines except processing the refund. </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">I want to Place bulk orders or need some specific products who do I contact?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">You can write to us at <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="563f3830391625213f2525223f3b333e392325337835393b">[email&#160;protected]</a> for all bulk orders, we will assist you with quotes and information based on the emails.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Can I order without creating an account?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Yes, without an account you can place an order at www.swisstimehouse.com as a guest by providing us the details via WhatsApp @ +91 91426 44444, but creating an account makes sure that you are updated with latest promotions/offers/order related changes and also every time you order you would not be needing to enter shipping address again and again.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">What if I'm not home to receive my order?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">www.swisstimehouse.com uses 3rd party courier companies for deliveries. Most Courier companies generally make 3 attempts to deliver the products. They also leave a note for a call back in case the door is unanswered. The courier company itself may leave an intimation for you or may call you to check for a time convenient to deliver, in case they don't find you at home. Please give a delivery time that will suit your schedule.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">What if products ordered by me are out of stock?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">All products shown on the web store are products in stock. In an exceptional case where the product ordered by you is out of stock or do not meet our quality guidelines, the same will be communicated to you within 24 hours and a refund will be processed immediately in case you wish to cancel the order.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Will I get warranty for products purchased from Factory Outlet?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">The product sold by Watch Station International - Factory Outlet Store is a certified product which may have been kept on display/demo purposes in stores and hence may have minor scratches, which are not covered under warranty. However this product comes with the Standard Manufacturer Warranty, as applicable to the new products of the manufacturer.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">How do I know that my credit/ debit card payment is safe?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Payments are accepted through certified third-party payment gateways. These gateways are certified for all security aspects.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Can I pay through Net banking? What is the procedure?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Yes, one can pay through net banking. You need to select net banking as an option on the checkout page and you will be redirected to the payment gateway. You will need to select net banking and the bank you wish to pay from and make the payment.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Does www.swisstimehouse.com offer an EMI option?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">Yes, EMI options are available at <a href="https://www.swisstimehouse.com/" style="box-sizing: border-box; color: #909090; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s;">www.swisstimehouse.com</a>. Currently EMI is available on credit cards from HDFC, ICICI, Axis, Kotak, Citi, BOB, HSBC, Ratnakar, Standard Chartered, Yes Bank, Bajaj Finance and Swiss Pay.</p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"> </p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;"><span style="box-sizing: border-box; font-weight: bolder;">Does my Billing address and the shipment address have to be the same?</span></p><p class="MsoNormal" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0.8rem; color: #666666; font-family: montserrat, sans-serif; font-size: 13px; background-color: #f5f5f5;">No, Shipping Address and Billing Address can be different.</p></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-104c96a elementor-section-content-middle elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="104c96a" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-43b67c3 ce-mobile-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="43b67c3" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-d15a3f0 elementor-widget elementor-widget-text-editor" data-id="d15a3f0" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p>the timekepeers</p></div>        </div>
+                <div class="elementor-element elementor-element-a244fe6 elementor-widget elementor-widget-heading" data-id="a244fe6" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h3 class="elementor-heading-title">since 1946</h3></div>        </div>
+                <div class="elementor-element elementor-element-bc511f9 elementor-widget elementor-widget-divider" data-id="bc511f9" data-element_type="widget" data-widget_type="divider.default">
+        <div class="elementor-widget-container">        <div class="elementor-divider">
+            <span class="elementor-divider-separator">
+                        </span>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-6adda8e elementor-column elementor-col-50 elementor-top-column" data-id="6adda8e" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-8056c2a elementor-position-left elementor-mobile-position-left elementor-view-default elementor-vertical-align-top elementor-widget elementor-widget-icon-box" data-id="8056c2a" data-element_type="widget" data-widget_type="icon-box.default">
+        <div class="elementor-widget-container">        <div class="elementor-icon-box-wrapper">
+                    <div class="elementor-icon-box-icon">
+                <span class="elementor-icon elementor-animation-grow">
+                    <i aria-hidden="true" class="fas fa-shield-halved"></i>                </span>
+            </div>
+                    <div class="elementor-icon-box-content">
+                            <h3 class="elementor-icon-box-title">
+                    <span  >
+                        Authorized Retailer - Since 1946                    </span>
+                </h3>
+                                        <p class="elementor-icon-box-description">Authorized retailer for over 70 brands. All products are 100% genuine and covered by manufacturer warranty.</p>
+                        </div>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-3db2d7a elementor-position-left elementor-mobile-position-left elementor-view-default elementor-vertical-align-top elementor-widget elementor-widget-icon-box" data-id="3db2d7a" data-element_type="widget" data-widget_type="icon-box.default">
+        <div class="elementor-widget-container">        <div class="elementor-icon-box-wrapper">
+                    <div class="elementor-icon-box-icon">
+                <span class="elementor-icon elementor-animation-grow">
+                    <i aria-hidden="true" class="fas fa-hands-holding-circle"></i>                </span>
+            </div>
+                    <div class="elementor-icon-box-content">
+                            <h3 class="elementor-icon-box-title">
+                    <span  >
+                        Secure Payments                    </span>
+                </h3>
+                                        <p class="elementor-icon-box-description">Debit / Credit Cards , Internet Banking , Bank Transfers, UPI and Wallets. EMI on major bank credit cards and Bajaj Finance , Swiss Pay - no credit card required.</p>
+                        </div>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-52785b2 elementor-position-left elementor-mobile-position-left elementor-view-default elementor-vertical-align-top elementor-widget elementor-widget-icon-box" data-id="52785b2" data-element_type="widget" data-widget_type="icon-box.default">
+        <div class="elementor-widget-container">        <div class="elementor-icon-box-wrapper">
+                    <div class="elementor-icon-box-icon">
+                <span class="elementor-icon elementor-animation-grow">
+                    <i aria-hidden="true" class="fas fa-truck-plane"></i>                </span>
+            </div>
+                    <div class="elementor-icon-box-content">
+                            <h3 class="elementor-icon-box-title">
+                    <span  >
+                        Free & Fast Delivery                    </span>
+                </h3>
+                                        <p class="elementor-icon-box-description">Delivery in 2 to 6 business days within India. In Store Pickup available.</p>
+                        </div>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-ed4f78a elementor-position-left elementor-mobile-position-left elementor-view-default elementor-vertical-align-top elementor-widget elementor-widget-icon-box" data-id="ed4f78a" data-element_type="widget" data-widget_type="icon-box.default">
+        <div class="elementor-widget-container">        <div class="elementor-icon-box-wrapper">
+                    <div class="elementor-icon-box-icon">
+                <span class="elementor-icon elementor-animation-grow">
+                    <i aria-hidden="true" class="fas fa-arrow-right-arrow-left"></i>                </span>
+            </div>
+                    <div class="elementor-icon-box-content">
+                            <h3 class="elementor-icon-box-title">
+                    <span  >
+                        Easy Exchange                    </span>
+                </h3>
+                                        <p class="elementor-icon-box-description">You can now exchange the product within 7 days of purchase.</p>
+                        </div>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-13aa7ecf elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="13aa7ecf" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-44d1db5a elementor-column elementor-col-100 elementor-top-column" data-id="44d1db5a" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-5810bd00 elementor-arrows-position-outside elementor-widget elementor-widget-product-carousel elementor-widget-heading elementor-widget-product-box" data-id="5810bd00" data-element_type="widget" data-settings="{&quot;product_spacing_custom&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:0,&quot;sizes&quot;:[]},&quot;navigation&quot;:&quot;arrows&quot;,&quot;slides_to_show_mobile&quot;:&quot;2&quot;,&quot;slides_to_show&quot;:&quot;6&quot;,&quot;slides_to_show_tablet&quot;:&quot;4&quot;,&quot;default_slides_count&quot;:4,&quot;autoplay&quot;:&quot;yes&quot;,&quot;pause_on_hover&quot;:&quot;yes&quot;,&quot;pause_on_interaction&quot;:&quot;yes&quot;,&quot;autoplay_speed&quot;:5000,&quot;infinite&quot;:&quot;yes&quot;,&quot;infinite_tablet&quot;:&quot;yes&quot;,&quot;infinite_mobile&quot;:&quot;yes&quot;,&quot;speed&quot;:500,&quot;direction&quot;:&quot;ltr&quot;,&quot;product_spacing_custom_tablet&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;product_spacing_custom_mobile&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]}}" data-widget_type="product-carousel.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title">You may also like</h2>        <div class="elementor-carousel-wrapper swiper swiper-custom" dir="ltr" role="region" aria-roledescription="carousel" aria-label="Product Carousel">
+            <div class="swiper-wrapper"><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="128295" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-d432" aria-label="Casio D432 Men&#039;s Watch, ₹ 4,495" aria-describedby="elementor-description-128295-5810bd00 elementor-category-128295-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/207380-medium_default/casio-d432.jpg" loading="lazy" alt="Casio D432 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                    <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128295-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Vintage Watches                </div>
+                            <h3 class="elementor-title">Casio D432 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 4,495</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128295-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Vintage Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio D432 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 4,495</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="128296" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-d433" aria-label="Casio D433 Men&#039;s Watch, ₹ 4,495" aria-describedby="elementor-description-128296-5810bd00 elementor-category-128296-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/207384-medium_default/casio-d433.jpg" loading="lazy" alt="Casio D433 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128296-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Vintage Watches                </div>
+                            <h3 class="elementor-title">Casio D433 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 4,495</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128296-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Vintage Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio D433 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 4,495</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127795" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-g1795" aria-label="Casio G1795 Men&#039;s Watch, ₹ 12,995" aria-describedby="elementor-description-127795-5810bd00 elementor-category-127795-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205646-medium_default/casio-g1795.jpg" loading="lazy" alt="Casio G1795 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                    <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127795-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+                            <h3 class="elementor-title">Casio G1795 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 12,995</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127795-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio G1795 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 12,995</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127796" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-g1796" aria-label="Casio G1796 Men&#039;s Watch, ₹ 12,995" aria-describedby="elementor-description-127796-5810bd00 elementor-category-127796-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205656-medium_default/casio-g1796.jpg" loading="lazy" alt="Casio G1796 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                    <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127796-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+                            <h3 class="elementor-title">Casio G1796 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 12,995</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127796-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio G1796 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 12,995</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127797" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-g1799" aria-label="Casio G1799 Women&#039;s Watch, ₹ 10,995" aria-describedby="elementor-description-127797-5810bd00 elementor-category-127797-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205666-medium_default/casio-g1799.jpg" loading="lazy" alt="Casio G1799 Women&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                    <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127797-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+                            <h3 class="elementor-title">Casio G1799 Women's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 10,995</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127797-5810bd00">
+                    <span class="screen-reader-text">Category: </span>G-Shock Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio G1799 Women's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 10,995</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127729" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-a2546" aria-label="Casio A2546 Men&#039;s Watch, ₹ 6,295" aria-describedby="elementor-description-127729-5810bd00 elementor-category-127729-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205288-medium_default/casio-a2546.jpg" loading="lazy" alt="Casio A2546 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127729-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+                            <h3 class="elementor-title">Casio A2546 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 6,295</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127729-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio A2546 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 6,295</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127730" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-a2547" aria-label="Casio A2547 Men&#039;s Watch, ₹ 8,495" aria-describedby="elementor-description-127730-5810bd00 elementor-category-127730-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205290-medium_default/casio-a2547.jpg" loading="lazy" alt="Casio A2547 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127730-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+                            <h3 class="elementor-title">Casio A2547 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 8,495</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127730-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio A2547 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 8,495</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127731" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-a2548" aria-label="Casio A2548 Men&#039;s Watch, ₹ 7,995" aria-describedby="elementor-description-127731-5810bd00 elementor-category-127731-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205292-medium_default/casio-a2548.jpg" loading="lazy" alt="Casio A2548 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127731-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+                            <h3 class="elementor-title">Casio A2548 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 7,995</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127731-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio A2548 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 7,995</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127732" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-a2549" aria-label="Casio A2549 Men&#039;s Watch, ₹ 7,295" aria-describedby="elementor-description-127732-5810bd00 elementor-category-127732-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205294-medium_default/casio-a2549.jpg" loading="lazy" alt="Casio A2549 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127732-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+                            <h3 class="elementor-title">Casio A2549 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 7,295</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127732-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Enticer Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio A2549 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 7,295</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127698" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/casio-i135" aria-label="Casio I135 Men&#039;s Watch, ₹ 2,995" aria-describedby="elementor-description-127698-5810bd00 elementor-category-127698-5810bd00"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205167-medium_default/casio-i135.jpg" loading="lazy" alt="Casio I135 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                                                                                                    <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127698-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Youth Watches                </div>
+                            <h3 class="elementor-title">Casio I135 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 2,995</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127698-5810bd00">
+                    <span class="screen-reader-text">Category: </span>Youth Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Casio</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Casio I135 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <span class="elementor-price">₹ 2,995</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div></div>
+                                    <div class="elementor-swiper-button elementor-swiper-button-prev" role="button" tabindex="0" aria-label="Previous">
+                    <i class="ceicon-chevron-left"></i>                </div>
+                <div class="elementor-swiper-button elementor-swiper-button-next" role="button" tabindex="0" aria-label="Next">
+                    <i class="ceicon-chevron-right"></i>                </div>
+                                        </div>
+        <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"ItemList","itemListElement":[{"@type":"ListItem","position":0,"name":"Casio D432 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-d432"},{"@type":"ListItem","position":1,"name":"Casio D433 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-d433"},{"@type":"ListItem","position":2,"name":"Casio G1795 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-g1795"},{"@type":"ListItem","position":3,"name":"Casio G1796 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-g1796"},{"@type":"ListItem","position":4,"name":"Casio G1799 Women's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-g1799"},{"@type":"ListItem","position":5,"name":"Casio A2546 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-a2546"},{"@type":"ListItem","position":6,"name":"Casio A2547 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-a2547"},{"@type":"ListItem","position":7,"name":"Casio A2548 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-a2548"},{"@type":"ListItem","position":8,"name":"Casio A2549 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-a2549"},{"@type":"ListItem","position":9,"name":"Casio I135 Men's Watch","url":"https:\/\/www.swisstimehouse.com\/casio-i135"}]}</script></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-04d8949 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="04d8949" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-c113cb2 ce-widgets-space--gap elementor-column elementor-col-100 elementor-top-column" data-id="c113cb2" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-757e5b8 elementor-widget elementor-widget-shortcode" data-id="757e5b8" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container">
+<div class="fmesl-wrapper">
+
+    <div class="fmesl-header">
+        <h2>Same Day Pickup from below Stores</h2>       
+		<!-- <div class="store-filter">
+    <label>City:</label>
+
+    <select id="store-city-filter">
+        <option value="all">All Cities</option>
+
+                    <option value="Calicut">Calicut</option>
+                    <option value="Coimbatore">Coimbatore</option>
+        
+    </select>
+</div> -->
+<div class="header-right">
+	
+	 <div class="custom-nav">
+            <div class="swiper-button-prev custom-prev"></div>
+            <div class="swiper-button-next custom-next"></div>
+        </div>
+    </div>
+	</div>
+<div class="store-filter">
+		<div class="filter-field">
+			<label for="store-city-filter">City:</label>
+			<select id="store-city-filter">
+				<option value="all">All Cities</option>
+									<option value="Calicut">Calicut</option>
+									<option value="Coimbatore">Coimbatore</option>
+							</select>
+		</div>
+	</div>	
+<div class="city-tabs">
+    <button class="city-tab active" data-city="all">All</button>
+
+            <button class="city-tab" data-city="calicut">Calicut</button>
+            <button class="city-tab" data-city="coimbatore">Coimbatore</button>
+    </div>
+
+    <div class=" fmesl-swiper">
+        <div class="swiper-wrapper">
+
+                            <div class="swiper-slide   fmesl-store-card" data-city="Calicut">
+
+                    <img src="https://www.swisstimehouse.com/img/st/42-stores_default2x.jpg" />
+					<div class="fmes1_description">
+						<h4 class="fmes1_store_name">Casio Store, Focus Mall, Calicut</h4>
+
+						<p class="fmes1_address">Ground Floor, Focus Mall, Mavoor Road, Calicut -  673001, Calicut</p>
+
+						<p class="fmes1_phone">+91 74036 99999</p>
+
+					</div>                                   
+					
+
+					<div class="store-hours">
+
+					<div class="store-hours">
+						Monday - Sunday
+						10:30AM - 10:00PM
+					</div>
+
+					</div>	
+					<span class="pickup-label">IN-STORE PICKUP</span>
+
+                </div>
+                            <div class="swiper-slide   fmesl-store-card" data-city="Coimbatore">
+
+                    <img src="https://www.swisstimehouse.com/img/st/62-stores_default2x.jpg" />
+					<div class="fmes1_description">
+						<h4 class="fmes1_store_name">Casio Store, DB Road, Coimbatore</h4>
+
+						<p class="fmes1_address">Ground Floor, Yaseen Complex, West Thiruvenkatasamy Rd, R.S Puram, Coimbatore, Tamil Nadu, Coimbatore</p>
+
+						<p class="fmes1_phone">+91 77964 12345</p>
+
+					</div>                                   
+					
+
+					<div class="store-hours">
+
+					<div class="store-hours">
+						Monday - Sunday
+						10:00AM - 9:00PM
+					</div>
+
+					</div>	
+					<span class="pickup-label">IN-STORE PICKUP</span>
+
+                </div>
+            
+        </div>
+
+      <!--   <div class="swiper-button-next"></div>
+        <div class="swiper-button-prev"></div> -->
+    </div>
+
+</div>
+
+<style>
+
+.fmesl-wrapper {
+    padding: 40px 0;
+}
+
+.fmesl-header {
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    /*margin-bottom:20px;*/
+}
+
+.fmesl-store-card {     
+    padding:15px;
+   
+}
+
+.fmesl-store-card img {
+    width:100%;
+    border-radius:10px;
+}
+
+.pickup-label {
+    display:inline-block;
+    margin-top:10px;
+    font-weight:bold;
+    color:#e60023;
+}
+
+h4.fmes1_store_name {
+    font-family: Figtree;
+    font-weight: 600;
+    font-style: SemiBold;
+    font-size: 16px;
+    leading-trim: NONE;
+    line-height: 20px;
+    letter-spacing: 0px;
+    color: #1C1C1C;
+    padding-top: 20px;
+}
+
+p.fmes1_address {
+    font-family: Figtree;
+    font-weight: 400;
+    font-style: Regular;
+    font-size: 14px;
+    leading-trim: NONE;
+    line-height: 20px;
+    letter-spacing: 0px;
+    text-transform: capitalize;
+}
+p.fmes1_phone {
+    font-family: Figtree;
+    font-weight: 400;
+    font-style: Regular;
+    font-size: 14px;
+    leading-trim: NONE;
+    line-height: 20px;
+    letter-spacing: 0px;
+    text-transform: capitalize;
+}
+
+.swiper-slide.col-6.col-md-4.col-lg-3.fmesl-store-card {
+    box-shadow: none;
+}
+.fmesl-store-card img {
+    width: 100%;
+    border-radius: 20px;
+}
+
+@media screen and (max-width: 767px) {
+h4.fmes1_store_name {  
+    font-size: 14px;
+ 
+}
+  p.fmes1_address {  
+    font-size: 12px;
+  
+}
+p.fmes1_phone {
+       font-size: 12px;
+ 
+}
+.fmesl-header h2 {
+    font-size: 20px;
+}
+.store-filter {
+    display: none;
+}
+}
+
+.store-filter {
+    position: relative;
+    right: 0%;
+}
+.filter-field{
+    position: relative;
+    width: 220px;
+	
+}
+
+.filter-field select{
+    width: 100%;
+    padding: 14px 52px;
+    border:1px solid #ddd;
+    border-radius:30px;
+    font-size:14px;
+    background:#fff;
+    appearance:none;
+}
+
+.filter-field label{
+    position:absolute;
+    top: 15px;
+    left:14px;
+    background:#fff;
+    padding:0 6px;
+    font-size:12px;
+    color:#666;
+}
+.city-tabs{
+    display:none;
+}
+
+@media (max-width:767px){
+
+.city-tabs{
+    display:flex;
+    overflow-x:auto;
+    gap:10px;
+    padding:10px 0;
+    margin-bottom:15px;
+    scrollbar-width:none;
+}
+
+.city-tabs::-webkit-scrollbar{
+    display:none;
+}
+
+.city-tab{
+    white-space:nowrap;
+    padding:8px 16px;
+    border:1px solid #ddd;
+    border-radius:20px;
+    background:#fff;
+    font-size:13px;
+    cursor:pointer;
+}
+
+.city-tab.active{
+    background:#000;
+    color:#fff;
+    border-color:#000;
+}
+
+}
+
+.fmesl-swiper .swiper-button-next, .fmesl-swiper .swiper-button-prev {
+    top: 19%;
+    
+    left: auto;
+    transform: none;
+    position: absolute;
+    display: inline-flex;
+    z-index: 1;
+    cursor: pointer;
+    font-size: 25px !important;
+    color: rgba(238, 238, 238, .9);
+  
+    transform: translateY(-50%);
+    width: 40px;
+    height: 40px;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: rgba(0, 0, 0, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.9;
+    transition: all 0.25s ease;
+        width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: rgba(0, 0, 0, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.9;
+    transition: all 0.25s ease;
+}
+.swiper-button-next:after, .swiper-button-prev:after {
+    font-family: swiper-icons;
+    font-size: 20px; 
+   
+}
+.swiper-button-prev {
+    right: 50px;
+    left: auto;
+}
+.swiper.fmesl-swiper {
+    padding-top: 4%;
+}
+.fmesl-swiper{
+    overflow: hidden;  
+}
+/*navigation align*/
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+.custom-nav {
+    display: flex;
+    gap: 10px;
+    padding: 20px 10px 0 20px;
+}
+
+.custom-prev,
+.custom-next {
+    position: static; /* IMPORTANT */
+    transform: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #eee;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.custom-prev:after,
+.custom-next:after {
+    font-size: 16px;
+    color: #000;
+}
+
+</style>
+<script>
+function filterStores(selected){
+
+    selected = selected.toLowerCase();
+
+    const stores = document.querySelectorAll(".fmesl-store-card");
+
+    stores.forEach(function(store){
+
+        const city = store.getAttribute("data-city").toLowerCase();
+
+        if(selected === "all" || city === selected){
+            store.style.display = "";
+        } else {
+            store.style.display = "none";
+        }
+
+    });
+
+}
+
+
+
+document.addEventListener("change", function(e){
+
+    if(e.target && e.target.id === "store-city-filter"){
+        filterStores(e.target.value);
+    }
+
+});
+
+
+
+document.addEventListener("click", function(e){
+
+    if(e.target.classList.contains("city-tab")){
+
+        document.querySelectorAll(".city-tab").forEach(tab=>{
+            tab.classList.remove("active");
+        });
+
+        e.target.classList.add("active");
+
+        filterStores(e.target.dataset.city);
+
+    }
+
+});
+
+document.addEventListener("DOMContentLoaded", (event) => {
+ const storeSwiper = new Swiper('.fmesl-swiper', {
+        slidesPerView: 4,
+        slidesPerGroup: 1, // move 1 slide only
+        
+        loop: true,
+     loopFillGroupWithBlank: false, 
+
+       navigation: {
+    nextEl: '.custom-next',
+    prevEl: '.custom-prev'
+},
+
+        breakpoints: {
+            0: {
+                slidesPerView: 2
+            },
+            576: {
+                slidesPerView: 2
+            },
+            768: {
+                slidesPerView: 3
+            },
+            1200: {
+                slidesPerView: 4
+            }
+        }
+    });
+    });
+
+</script>
+
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-1de0f745 elementor-reverse-tablet elementor-reverse-mobile elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="1de0f745" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-extended">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-7d0937c6 elementor-column elementor-col-50 elementor-top-column" data-id="7d0937c6" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <section class="elementor-element elementor-element-31add61e elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-inner-section" data-id="31add61e" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;,&quot;sticky&quot;:&quot;top&quot;,&quot;sticky_offset&quot;:100,&quot;sticky_parent&quot;:&quot;yes&quot;,&quot;sticky_on&quot;:[],&quot;sticky_effects_offset&quot;:0}">
+                            <div class="elementor-container elementor-column-gap-no">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-1e1c9c5b elementor-column elementor-col-100 elementor-inner-column" data-id="1e1c9c5b" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-4f3ef170 elementor-cta--valign-middle elementor-widget-tablet__width-initial elementor-widget-mobile__width-inherit elementor-cta--skin-classic elementor-animated-content elementor-widget elementor-widget-call-to-action" data-id="4f3ef170" data-element_type="widget" data-widget_type="call-to-action.default">
+        <div class="elementor-widget-container">        <a class="elementor-cta" href="https://www.swisstimehouse.com/prices-drop">
+                    <div class="elementor-cta-bg-wrapper">
+                <img src="/img/cms/24%20october/sale%20banner_1.jpg" loading="lazy" width="828" height="1106" class="elementor-cta-bg elementor-bg">                <div class="elementor-cta-bg-overlay"></div>
+            </div>
+                            <div class="elementor-cta-content">
+            
+            
+                            <div class="elementor-cta-description elementor-content-item">
+                                     </div>
+            
+                        </div>
+                        </a>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-6266a2ba elementor-column elementor-col-50 elementor-top-column" data-id="6266a2ba" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-7c402e3c elementor-widget elementor-widget-product-carousel elementor-widget-heading elementor-widget-product-box" data-id="7c402e3c" data-element_type="widget" data-settings="{&quot;product_spacing_custom&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:0,&quot;sizes&quot;:[]},&quot;navigation&quot;:&quot;none&quot;,&quot;slides_to_show_mobile&quot;:&quot;2.6&quot;,&quot;slides_to_show&quot;:&quot;4.5&quot;,&quot;slides_to_show_tablet&quot;:&quot;4.5&quot;,&quot;default_slides_count&quot;:4,&quot;autoplay&quot;:&quot;yes&quot;,&quot;pause_on_hover&quot;:&quot;yes&quot;,&quot;pause_on_interaction&quot;:&quot;yes&quot;,&quot;autoplay_speed&quot;:5000,&quot;infinite&quot;:&quot;yes&quot;,&quot;infinite_tablet&quot;:&quot;yes&quot;,&quot;infinite_mobile&quot;:&quot;yes&quot;,&quot;speed&quot;:500,&quot;direction&quot;:&quot;ltr&quot;,&quot;product_spacing_custom_tablet&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;product_spacing_custom_mobile&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]}}" data-widget_type="product-carousel.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title">Special Offers</h2>        <div class="elementor-carousel-wrapper swiper swiper-custom" dir="ltr" role="region" aria-roledescription="carousel" aria-label="Product Carousel">
+            <div class="swiper-wrapper"><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="128294" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/tornado-t25103-ssrrb" aria-label="Tornado T25103-SSRRB Men&#039;s Watch, ₹ 22,080" aria-describedby="elementor-description-128294-7c402e3c elementor-category-128294-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/207375-medium_default/tornado-t25103-ssrrb.jpg" loading="lazy" alt="Tornado T25103-SSRRB Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -20%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128294-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+                            <h3 class="elementor-title">Tornado T25103-SSRRB Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 27,600</del>
+                                    <span class="elementor-price">₹ 22,080</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128294-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Tornado</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Tornado T25103-SSRRB Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 27,600</del>
+                                    <span class="elementor-price">₹ 22,080</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="128157" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/skagen-skw3005" aria-label="Skagen SKW3005 Women&#039;s Watch, ₹ 6,396" aria-describedby="elementor-description-128157-7c402e3c elementor-category-128157-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/206829-medium_default/skagen-skw3005.jpg" loading="lazy" alt="Skagen SKW3005 Women&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -20%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128157-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Skagen Watches                </div>
+                            <h3 class="elementor-title">Skagen SKW3005 Women's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 7,995</del>
+                                    <span class="elementor-price">₹ 6,396</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-128157-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Skagen Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Skagen</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Skagen SKW3005 Women's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 7,995</del>
+                                    <span class="elementor-price">₹ 6,396</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127744" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/fastrack-38088pp01" aria-label="Fastrack 38088PP01 Men&#039;s Watch, ₹ 1,699" aria-describedby="elementor-description-127744-7c402e3c elementor-category-127744-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205358-medium_default/fastrack-38088pp01.jpg" loading="lazy" alt="Fastrack 38088PP01 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -57.47%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127744-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Fastrack Watches                </div>
+                            <h3 class="elementor-title">Fastrack 38088PP01 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 3,995</del>
+                                    <span class="elementor-price">₹ 1,699</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127744-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Fastrack Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Fastrack</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Fastrack 38088PP01 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 3,995</del>
+                                    <span class="elementor-price">₹ 1,699</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127745" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/fastrack-38088pp07" aria-label="Fastrack 38088PP07 Men&#039;s Watch, ₹ 1,699" aria-describedby="elementor-description-127745-7c402e3c elementor-category-127745-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205362-medium_default/fastrack-38088pp07.jpg" loading="lazy" alt="Fastrack 38088PP07 Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -57.47%                    </div>
+                                                                                                                        <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127745-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Fastrack Watches                </div>
+                            <h3 class="elementor-title">Fastrack 38088PP07 Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 3,995</del>
+                                    <span class="elementor-price">₹ 1,699</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127745-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Fastrack Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Fastrack</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Fastrack 38088PP07 Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 3,995</del>
+                                    <span class="elementor-price">₹ 1,699</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127714" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/daniel-wellington-dw00100854k" aria-label="Daniel Wellington DW00100854K Women&#039;s Watch, ₹ 10,197" aria-describedby="elementor-description-127714-7c402e3c elementor-category-127714-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205213-medium_default/daniel-wellington-dw00100854k.jpg" loading="lazy" alt="Daniel Wellington DW00100854K Women&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -40%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127714-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Daniel Wellington Watches                </div>
+                            <h3 class="elementor-title">Daniel Wellington DW00100854K Women's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 16,995</del>
+                                    <span class="elementor-price">₹ 10,197</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127714-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Daniel Wellington Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Daniel Wellington</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Daniel Wellington DW00100854K Women's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 16,995</del>
+                                    <span class="elementor-price">₹ 10,197</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127712" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/daniel-wellington-dw00100581k" aria-label="Daniel Wellington DW00100581K Women&#039;s Watch, ₹ 8,997" aria-describedby="elementor-description-127712-7c402e3c elementor-category-127712-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/205206-medium_default/daniel-wellington-dw00100581k.jpg" loading="lazy" alt="Daniel Wellington DW00100581K Women&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -40%                    </div>
+                                                                                                                        <div class="elementor-badge elementor-badge-out">
+                        Sold Out                    </div>
+                                                                    </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127712-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Daniel Wellington Watches                </div>
+                            <h3 class="elementor-title">Daniel Wellington DW00100581K Women's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 14,995</del>
+                                    <span class="elementor-price">₹ 8,997</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127712-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Daniel Wellington Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Daniel Wellington</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Daniel Wellington DW00100581K Women's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 14,995</del>
+                                    <span class="elementor-price">₹ 8,997</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127616" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/tornado-t21001-xbxnk" aria-label="Tornado T21001-XBXNK Men&#039;s Watch, ₹ 14,000" aria-describedby="elementor-description-127616-7c402e3c elementor-category-127616-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/204902-medium_default/tornado-t21001-xbxnk.jpg" loading="lazy" alt="Tornado T21001-XBXNK Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -30%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127616-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+                            <h3 class="elementor-title">Tornado T21001-XBXNK Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 20,000</del>
+                                    <span class="elementor-price">₹ 14,000</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127616-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Tornado</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Tornado T21001-XBXNK Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 20,000</del>
+                                    <span class="elementor-price">₹ 14,000</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127582" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/tornado-t25104s-sbsw-b" aria-label="Tornado T25104S- SBSW-B Men&#039;s Watch, ₹ 21,992" aria-describedby="elementor-description-127582-7c402e3c elementor-category-127582-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/204752-medium_default/tornado-t25104s-sbsw-b.jpg" loading="lazy" alt="Tornado T25104S- SBSW-B Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -10%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127582-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+                            <h3 class="elementor-title">Tornado T25104S- SBSW-B Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 24,435</del>
+                                    <span class="elementor-price">₹ 21,992</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127582-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Tornado</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Tornado T25104S- SBSW-B Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 24,435</del>
+                                    <span class="elementor-price">₹ 21,992</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127583" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/tornado-t25104s-slbw-b" aria-label="Tornado T25104S- SLBW-B Men&#039;s Watch, ₹ 21,101" aria-describedby="elementor-description-127583-7c402e3c elementor-category-127583-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/204757-medium_default/tornado-t25104s-slbw-b.jpg" loading="lazy" alt="Tornado T25104S- SLBW-B Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -10%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127583-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+                            <h3 class="elementor-title">Tornado T25104S- SLBW-B Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 23,445</del>
+                                    <span class="elementor-price">₹ 21,101</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127583-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Tornado</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Tornado T25104S- SLBW-B Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 23,445</del>
+                                    <span class="elementor-price">₹ 21,101</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div><div class="swiper-slide">        <article class="elementor-product-miniature" data-id-product="127584" data-id-product-attribute="0">
+            <a class="elementor-product-link" href="https://www.swisstimehouse.com/tornado-t25104s-sldi-d" aria-label="Tornado T25104S- SLDI-D Men&#039;s Watch, ₹ 21,101" aria-describedby="elementor-description-127584-7c402e3c elementor-category-127584-7c402e3c"></a>
+            <div class="elementor-image">
+                <picture class="elementor-cover-image">
+                                                    <img src="https://www.swisstimehouse.com/204762-medium_default/tornado-t25104s-sldi-d.jpg" loading="lazy" alt="Tornado T25104S- SLDI-D Men&#039;s Watch"
+                        width="452" height="584">
+                </picture>
+                                    </div>
+                    <div class="elementor-badges-left">
+                                                                                                                                                                    </div>
+                    <div class="elementor-badges-right">
+                                                <div class="elementor-badge elementor-badge-sale">
+                        -10%                    </div>
+                                                                                                                                                        </div>
+                   <!--- <div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127584-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+                            <h3 class="elementor-title">Tornado T25104S- SLDI-D Men's Watch</h3>
+                                        <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 23,445</del>
+                                    <span class="elementor-price">₹ 21,101</span>
+                </div>
+                        </div> --->
+			
+			
+			
+			
+			
+			<div class="elementor-content">
+                            <div class="elementor-category" id="elementor-category-127584-7c402e3c">
+                    <span class="screen-reader-text">Category: </span>Tornado Watches                </div>
+            	
+			<!---jay brand --->	
+									<p class="custom-elementor-brand elementor-title">Tornado</p>
+						
+				<!---jay brand end--->		
+                <h3 class="elementor-title">Tornado T25104S- SLDI-D Men's Watch</h3>
+             <!---jay feature --->	
+							
+					<!---jay feature end--->	
+			
+			                            <div class="elementor-price-wrapper">
+                                    <del class="elementor-price-regular">₹ 23,445</del>
+                                    <span class="elementor-price">₹ 21,101</span>
+                </div>
+                        </div>
+			
+			
+			
+			
+			
+                </article>
+        </div></div>
+                                                </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-953096e elementor-reverse-tablet elementor-reverse-mobile elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="953096e" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-extended">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-fbb6b27 elementor-column elementor-col-100 elementor-top-column" data-id="fbb6b27" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <div class="elementor-element elementor-element-11cb7306 elementor-section-full_width elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="11cb7306" data-element_type="section" id="stickycustom" data-settings="{&quot;sticky&quot;:&quot;bottom&quot;,&quot;sticky_offset&quot;:89,&quot;sticky_on&quot;:[&quot;desktop&quot;,&quot;tablet&quot;,&quot;mobile&quot;],&quot;sticky_effects_offset&quot;:0}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-6a8515c3 ce-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="6a8515c3" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-2ea1b346 elementor-align-center elementor-widget-mobile__width-auto elementor-mobile-align-center elementor-widget__width-auto ce-product-prices--layout-stacked elementor-widget elementor-widget-product-price elementor-overflow-hidden" data-id="2ea1b346" data-element_type="widget" data-widget_type="product-price.default">
+        <div class="elementor-widget-container"><div style="display:none" class="jay">IN G-Shock Watches Casio</div>		
+        <div class="ce-product-prices">
+                    <div class="ce-product-price ce-has-discount">
+                <span class="screen-reader-text">Reduced price:</span>
+                <span>₹ 34,997</span
+                                    ><span class="ce-product-badge ce-product-badge-sale ce-product-badge-sale-percentage">
+                    Save 30%                </span
+                    >
+            </div>
+                                                                <div class="ce-tax-shipping-delivery-label">Tax included                    <div class="snap_emi_txt"></div>
+
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="34997" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="products_page"></span>
+
+<script>
+    (function () {
+        var snapmint = document.createElement('script');
+        snapmint.type = 'text/javascript';
+        snapmint.async = true;
+        snapmint.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 
+            'merchant-js.snapmint.com/assets/merchant/4797/snapmint_emi.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(snapmint, s);
+    })();
+</script></div>
+                </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-77b1cd37 ce-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="77b1cd37" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-1c850444 elementor-button-primary elementor-align-justify elementor-widget-mobile__width-auto remove_on_cfp elementor-mobile-align-justify elementor-widget__width-auto elementor-widget elementor-widget-product-add-to-cart elementor-widget-button" data-id="1c850444" data-element_type="widget" data-widget_type="product-add-to-cart.default">
+        <div class="elementor-widget-container">        <a href="#ce-action=addToCart" role="button" class="elementor-button elementor-size-xs">
+            <span class="elementor-button-content-wrapper">
+                        <span class="elementor-button-icon elementor-align-icon-left" aria-hidden="true"><i class="ceicon-basket-solid"></i></span>
+                                    <span class="elementor-button-text">Add to Cart</span>
+                        </span>
+        </a>
+        </div>        </div>
+                <div class="elementor-element elementor-element-1a845752 elementor-widget-mobile__width-auto elementor-widget__width-inherit elementor-widget elementor-widget-shortcode" data-id="1a845752" data-element_type="widget" data-widget_type="shortcode.default">
+        <div class="elementor-widget-container"><div class="stickybarcustom ">
+
+</div>
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </div>
+                    </div>
+        </div>
+        
+	</section>
+	
+		
+		<footer id="footer" class="footer">
+			
+					        <div data-elementor-type="footer" data-elementor-id="27170101" class="elementor elementor-27170101">
+            <div class="elementor-section-wrap">
+                        <section class="elementor-element elementor-element-358bbe57 elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="358bbe57" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-3ac0891 ce-mobile-valign-center elementor-column elementor-col-50 elementor-top-column" data-id="3ac0891" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-36e1ca7 elementor-widget elementor-widget-text-editor" data-id="36e1ca7" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p>sign up to our</p></div>        </div>
+                <div class="elementor-element elementor-element-5ab408a elementor-widget elementor-widget-heading" data-id="5ab408a" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h3 class="elementor-heading-title">newsletter</h3></div>        </div>
+                <div class="elementor-element elementor-element-21f0dd1a elementor-widget elementor-widget-text-editor" data-id="21f0dd1a" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p>Stay updated with the latest offers, trends and launches, subscribe to our newsletters. Get exclusive invite to private sales and much more.</p></div>        </div>
+                <div class="elementor-element elementor-element-2b024a8 elementor-widget elementor-widget-divider" data-id="2b024a8" data-element_type="widget" data-widget_type="divider.default">
+        <div class="elementor-widget-container">        <div class="elementor-divider">
+            <span class="elementor-divider-separator">
+                        </span>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-2d4af9f0 elementor-column elementor-col-50 elementor-top-column" data-id="2d4af9f0" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-4de4a73 elementor-mobile-align-justify elementor-mobile-layout-multiline elementor-layout-inline elementor-tablet-layout-inline elementor-button-classic elementor-widget elementor-widget-email-subscription" data-id="4de4a73" data-element_type="widget" data-widget_type="email-subscription.default">
+        <div class="elementor-widget-container">        <form class="ce-subscribe-form elementor-form" method="post" action="https://www.swisstimehouse.com/module/creativeelements/ajax">
+            <div class="elementor-form-fields-wrapper">
+                <input type="hidden" name="action" value="0">
+                <div class="elementor-field-group elementor-column elementor-col-100 elementor-field-type-subscribe">
+                    <input type="email" name="email" class="elementor-field elementor-field-textual" placeholder="    Your email address" inputmode="email" required>
+                    <button type="submit" name="submitNewsletter" value="1" class="elementor-button elementor-size-sm">
+                        <span class="elementor-button-content-wrapper">
+                                                                            <span class="elementor-button-text">Subscribe</span>
+                                                </span>
+                    </button>
+                </div>
+                        </div>
+        </form>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-b0d824f elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="b0d824f" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-971c5ad elementor-column elementor-col-100 elementor-top-column" data-id="971c5ad" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-9d35853 elementor-widget elementor-widget-divider" data-id="9d35853" data-element_type="widget" data-widget_type="divider.default">
+        <div class="elementor-widget-container">        <div class="elementor-divider">
+            <span class="elementor-divider-separator">
+                        </span>
+        </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-31b041de cbp-links cbp-valinks elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="31b041de" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-38cd2afd elementor-column elementor-col-25 elementor-top-column" data-id="38cd2afd" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-32acf55c elementor-widget elementor-widget-heading" data-id="32acf55c" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/watches">ONLINE SHOPPING</a></h2></div>        </div>
+                <div class="elementor-element elementor-element-2f0a920e .cbp-links.cbp-valinks elementor-widget elementor-widget-text-editor" data-id="2f0a920e" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p></p><ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 14px; white-space: nowrap; background-color: #000000;"><ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 14px; white-space: nowrap; background-color: #000000;"><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #fff !important;">Home</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/mens-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #fff !important;">Men's Watches</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/product-catalogue/womens-watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #fff !important;">Women's Watches</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/fashion-brands" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Fashion Brands</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/luxury-brands" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Luxury Brands</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/smart-watch-brands" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Smart Watches</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/new-products?products=watches" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">New Products</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/prices-drop" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Price Drop</a></li></ul></ul><div class="block-content"></div><div class="block-content"></div></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-55471b06 elementor-column elementor-col-25 elementor-top-column" data-id="55471b06" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-1f3e452e elementor-widget elementor-widget-heading" data-id="1f3e452e" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/privacy-policy">CUSTOMER POLICIES</a></h2></div>        </div>
+                <div class="elementor-element elementor-element-309bcf58 elementor-widget elementor-widget-text-editor" data-id="309bcf58" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p></p><ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 14px; white-space: nowrap; background-color: #000000;"><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/privacy-policy" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Privacy Policy</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/delivery-information-of-orders" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Delivery Policy</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/delivery-information-of-orders" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Shipping Policy<br /></a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/return-policy" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Return Policy</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/terms-and-conditions-of-use" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Terms &amp; Conditions<br /></a></li></ul><div class="block-content"></div></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-d33dde6 elementor-column elementor-col-25 elementor-top-column" data-id="d33dde6" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-36967214 elementor-widget elementor-widget-heading" data-id="36967214" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/login?back=my-account">USEFUL LINKS</a></h2></div>        </div>
+                <div class="elementor-element elementor-element-140a794 elementor-widget elementor-widget-text-editor" data-id="140a794" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p></p><ul class="cbp-links cbp-valinks" style="box-sizing: border-box; margin: 0px; list-style: none; padding: 0px; font-family: Montserrat, sans-serif; font-size: 14px; white-space: nowrap; background-color: #000000;"><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/login?back=my-account" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">My Account</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/about-us" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">About Us</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/our-stores" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Our Stores<br /></a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/careers" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Careers</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/contact-us" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Contact Us<br /></a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="https://www.swisstimehouse.com/blog" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Blogs</a></li><li style="box-sizing: border-box; margin: 3px 0px; padding-left: 2px; position: relative;"><a href="#" id="modifyConsent" style="box-sizing: border-box; text-decoration-line: none; background-color: transparent; transition: opacity 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s, color 0.2s cubic-bezier(0.7, 0, 0.3, 1) 0s; padding-left: 10px; display: inline-block; color: #ffffff !important;">Manage Cookies</a></li></ul><div class="block-content"></div></div>        </div>
+                        </div>
+            </div>
+        </div>
+                <div class="elementor-element elementor-element-46c8ffd2 elementor-column elementor-col-25 elementor-top-column" data-id="46c8ffd2" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-18f2196b elementor-widget elementor-widget-heading" data-id="18f2196b" data-element_type="widget" data-widget_type="heading.default">
+        <div class="elementor-widget-container"><h2 class="elementor-heading-title"><a href="https://www.swisstimehouse.com/contact-us">CORPORATE ADDRESS</a></h2></div>        </div>
+                <div class="elementor-element elementor-element-bbe2dde elementor-widget elementor-widget-html" data-id="bbe2dde" data-element_type="widget" data-widget_type="html.default">
+        <div class="elementor-widget-container"><div style="font-size: 15px; line-height: 1.8; color: #fff;">
+  <strong>Swiss Group India Pvt Ltd</strong><br>
+  📍 Ground Floor, GCDA Complex, Marine Drive, Cochin - 682031<br>
+  📞 <a href="tel:+919142012345" style="color: #fff; text-decoration: none;">+91 91420 12345</a><br>
+  <i class="fab fa-whatsapp" style="color: #25D366;"></i> 
+<a href="https://wa.me/919142644444" target="_blank" style="color: #fff; text-decoration: none;">+91 91426 44444</a><br>
+  ✉️ <a href="/cdn-cgi/l/email-protection#32414742425d40467241455b4141465b5f575a5d4741571c515d5f" style="color: #fff; text-decoration: none;"><span class="__cf_email__" data-cfemail="01727471716e737541727668727275686c64696e7472642f626e6c">[email&#160;protected]</span></a>
+</div>
+</div>        </div>
+                <div class="elementor-element elementor-element-13b81277 elementor-shape-rounded elementor-grid-0 elementor-widget elementor-widget-social-icons" data-id="13b81277" data-element_type="widget" data-widget_type="social-icons.default">
+        <div class="elementor-widget-container">        <div class="elementor-social-icons-wrapper elementor-grid" role="list">
+                    <span class="elementor-grid-item" role="listitem">
+                <a class="elementor-icon elementor-social-icon elementor-social-icon-facebook elementor-repeater-item-9926c74" href="https://www.facebook.com/SwissTimeHouse/" target="_blank" aria-label="Facebook">
+                    <i class="fab fa-facebook-f"></i>                </a>
+            </span>
+                    <span class="elementor-grid-item" role="listitem">
+                <a class="elementor-icon elementor-social-icon elementor-social-icon-instagram elementor-repeater-item-5f2c879" href="https://www.instagram.com/swisstimehouse" target="_blank" aria-label="Instagram">
+                    <i class="fab fa-instagram"></i>                </a>
+            </span>
+                    <span class="elementor-grid-item" role="listitem">
+                <a class="elementor-icon elementor-social-icon elementor-social-icon-youtube elementor-repeater-item-a507e68" href="https://www.youtube.com/channel/UCxRYEjMn-UFoxDq94twrmlw" target="_blank" aria-label="Youtube">
+                    <i class="fab fa-youtube"></i>                </a>
+            </span>
+                    <span class="elementor-grid-item" role="listitem">
+                <a class="elementor-icon elementor-social-icon elementor-social-icon-linkedin elementor-repeater-item-6e2732e" href="https://www.linkedin.com/company/90736165/" target="_blank" aria-label="Linkedin">
+                    <i class="fab fa-linkedin-in"></i>                </a>
+            </span>
+                    <span class="elementor-grid-item" role="listitem">
+                <a class="elementor-icon elementor-social-icon elementor-social-icon-twitter elementor-repeater-item-50bbb44" href="https://twitter.com/swiss_1946?lang=en" target="_blank" aria-label="Twitter">
+                    <i class="fab fa-twitter"></i>                </a>
+            </span>
+                </div>
+        </div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-f4dc1b6 elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="f4dc1b6" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-28285054 elementor-column elementor-col-100 elementor-top-column" data-id="28285054" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-7d52af6a elementor-widget__width-inherit elementor-widget elementor-widget-text-editor" data-id="7d52af6a" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p><span style="color: #000000;"><strong>POPULAR SEARCHES</strong></span><br /><span style="color: #000000;"><a href="https://www.swisstimehouse.com/product-catalogue/mens-watches" style="color: #000000;">Watches for Men</a> I <a href="https://www.swisstimehouse.com/product-catalogue/womens-watches" style="color: #000000;">Women's Watches</a>  I <a href="https://www.swisstimehouse.com/product-catalogue/smart-watches/" style="color: #000000;">SmartWatches</a> I <a href="https://www.swisstimehouse.com/luxury-brands" style="color: #000000;">Wedding Gifts</a> I   <a href="https://www.swisstimehouse.com/fashion-brands" style="color: #000000;">Fashion Brands</a> I  <a href="https://www.swisstimehouse.com/product-catalogue/watches/band-material-leather" style="color: #000000;">Leather Watches</a>  I <a href="https://www.swisstimehouse.com/product-catalogue/watches/features-chronograph" style="color: #000000;">Chronogrph Watches</a> I <a href="https://www.swisstimehouse.com/g-shock-watches" style="color: #000000;">Casio G-Shock</a> I <a href="https://www.swisstimehouse.com/manufacturer/fossil" style="color: #000000;">Fossil Watches</a> I  <a href="https://www.swisstimehouse.com/manufacturer/titan" style="color: #000000;">Titan Watches</a> I  <a href="https://www.swisstimehouse.com/manufacturer/rado" style="color: #000000;">Rado Watches</a> I  <a href="https://www.swisstimehouse.com/tissot-watches?gender=men" style="color: #000000;">Tissot Watches for Men</a> I  <a href="https://www.swisstimehouse.com/vintage-watches" style="color: #000000;">Casio Vintage</a> I  <a href="https://www.swisstimehouse.com/casio-watches" style="color: #000000;"> Casio Watches</a> I  <a href="https://www.swisstimehouse.com/product-catalogue/watches/band-material-metal-steel" style="color: #000000;">Steel Watches</a> I <a href="https://www.swisstimehouse.com/product-catalogue/watches/glass-sapphire-crystal" style="color: #000000;"> Sapphire Crystal Watches</a> I   <a href="https://www.swisstimehouse.com/rolex" style="color: #000000;">Rolex</a> I  <a href="https://www.swisstimehouse.com/manufacturer/omega" style="color: #000000;">Omega Watches</a> I   <a href="https://www.swisstimehouse.com/manufacturer/fastrack" style="color: #000000;">Fastrack Watches</a> I   <a href="https://www.swisstimehouse.com/watches?price=5000-20000" style="color: #000000;">Watches below Rs.20000</a> I <a href="https://www.swisstimehouse.com/luxury-brands" style="color: #000000;"> Luxury Watches</a> I  <a href="https://www.swisstimehouse.com/product-catalogue/swiss-made" style="color: #000000;">Swiss Made Watches</a>  I <a href="https://www.swisstimehouse.com/manufacturer/diesel" style="color: #000000;">Diesel</a><a href="https://www.swisstimehouse.com/manufacturer/diesel" style="color: #000000;"> Watches</a>  I <a href="https://www.swisstimehouse.com/product-catalogue/watches/band-color-gold" style="color: #000000;">Gold Watches</a> I   <a href="https://www.swisstimehouse.com/clocks" style="color: #000000;">Clocks</a> I  <a href="https://www.swisstimehouse.com/accessories?categories=belts,wallets" style="color: #000000;">Leather Accessories</a>  I <a href="https://www.swisstimehouse.com/longines" style="color: #000000;">Longines Watches</a>  I <a href="https://www.swisstimehouse.com/return-policy" style="color: #000000;">Return Policy</a> I<a href="https://www.swisstimehouse.com/edifice-watches" style="color: #000000;"> Casio Edifice</a> I<a href="https://www.swisstimehouse.com/manufacturer/emporio-armani" style="color: #000000;"> Emporio Armani Watches</a> I <a href="https://www.swisstimehouse.com/products?gender=kids" style="color: #000000;">Kids Watches</a> I <a href="https://www.swisstimehouse.com/products?gender=couple-watches" style="color: #000000;">Couple Watches</a> I <a href="https://www.swisstimehouse.com/manufacturer/seiko" style="color: #000000;">Seiko Watches</a> I <br /></span></p></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-63cab561 elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="63cab561" data-element_type="section">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-74db78b8 elementor-column elementor-col-100 elementor-top-column" data-id="74db78b8" data-element_type="column">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-4c1472d8 elementor-widget elementor-widget-text-editor" data-id="4c1472d8" data-element_type="widget" data-widget_type="text-editor.default">
+        <div class="elementor-widget-container"><p>© 2026 Powered by Swiss Group™. All Rights Reserved</p></div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                <section class="elementor-element elementor-element-45b85077 elementor-hidden-desktop elementor-hidden-tablet elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-section elementor-top-section" data-id="45b85077" data-element_type="section" data-settings="{&quot;sticky&quot;:&quot;bottom&quot;,&quot;sticky_offset&quot;:15,&quot;sticky_on&quot;:[&quot;desktop&quot;,&quot;tablet&quot;,&quot;mobile&quot;],&quot;sticky_effects_offset&quot;:0}">
+                            <div class="elementor-container elementor-column-gap-default">
+                            <div class="elementor-row">
+                <div class="elementor-element elementor-element-7980edbf ce-mobile-valign-center elementor-column elementor-col-100 elementor-top-column" data-id="7980edbf" data-element_type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+            <div class="elementor-column-wrap elementor-element-populated">
+                <div class="elementor-widget-wrap">
+                <div class="elementor-element elementor-element-4bf86eb elementor-widget__width-auto elementor-widget-tablet__width-auto mobile_menu elementor-widget-mobile__width-auto elementor-nav--text-align-aside elementor-nav--toggle elementor-nav--burger elementor-widget elementor-widget-nav-menu" data-id="4bf86eb" data-element_type="widget" data-settings="{&quot;layout&quot;:&quot;dropdown&quot;,&quot;submenu_icon&quot;:{&quot;value&quot;:&quot;fas fa-angle-down&quot;,&quot;library&quot;:&quot;fa-solid&quot;},&quot;show_submenu_on&quot;:&quot;hover&quot;,&quot;animation_dropdown&quot;:&quot;toggle&quot;,&quot;toggle&quot;:&quot;burger&quot;}" data-widget_type="nav-menu.default">
+        <div class="elementor-widget-container">        <a href="javascript://toggle" class="elementor-menu-toggle" role="button" aria-label="Menu" aria-expanded="false">
+            <i class="ceicon ceicon-menu" aria-hidden="true"></i>
+        </a>
+        <nav class="elementor-nav--dropdown elementor-nav__container" aria-label="Main Menu">        <ul class="elementor-nav" id="menu-2-4bf86eb">
+		<li class="logo_menu">
+        <img src="/img/swiss-time-house-logo-1665736482.jpg" /><div class="close_menu">
+        <i class="ceicon-close"></i>
+</div>
+      </li>                    <li class="menu-item menu-item-type-link menu-item-lnk-homepage">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/">
+                                    Homepage                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-12 menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/watches">
+                                    Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-140 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/luxury-brands">
+                                    Luxury & Premium Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-72">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/balmain-watches">
+                                    Balmain Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-354">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/movado-watches">
+                                    Movado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-watches">
+                                    Seiko Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-74">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/longines-watches">
+                                    Longines Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-73">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/omega-watches">
+                                    Omega Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rado-watches">
+                                    Rado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tag-heuer-watches">
+                                    Tag Heuer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-33">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tissot-watches">
+                                    Tissot Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-47">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-watches">
+                                    Victorinox Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-113">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rolex-watches">
+                                    Rolex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-327">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sevenfriday-watches">
+                                    SevenFriday Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-337">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/franck-muller-watches">
+                                    Franck Muller Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-848">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/gc-watches">
+                                    Gc Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-137 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fashion-brands">
+                                    Fashion Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-116">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/armani-exchange-watches">
+                                    Armani Exchange Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-355">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/hugo-boss-watches">
+                                    Hugo Boss Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calvin-klein-watches">
+                                    Calvin Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-18">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/diesel-watches">
+                                    Diesel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-915">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tornado-watches">
+                                    Tornado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-918">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/aston-martin-watches">
+                                    Aston Martin Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-920">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/off-road-watches">
+                                    Off Road Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/emporio-armani-watches">
+                                    Emporio Armani Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-913">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rock-revival-watches">
+                                    Rock Revival Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-917">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jean-fendi-watches">
+                                    Jean Fendi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-910">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/foce-watches">
+                                    Foce Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-32">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/esprit-watches">
+                                    Esprit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-148">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/giordano-watches">
+                                    Giordano Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-183">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-watches">
+                                    Kenneth Cole Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-149">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/michael-kors-watches">
+                                    Michael Kors Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-23">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/police-watches">
+                                    Police Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-107">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skagen-watches">
+                                    Skagen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-35">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/swatch-watches">
+                                    Swatch Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-24">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tommy-hilfiger-watches">
+                                    Tommy Hilfiger Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-256">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-watches">
+                                    Fossil Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-101">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/alba-watches">
+                                    Alba Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-262">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/obaku-watches">
+                                    Obaku Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-323">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/anne-klein-watches">
+                                    Anne Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-324">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/earnshaw-watches">
+                                    Earnshaw Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-326">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/strand-watches">
+                                    Strand Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-342">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/coach-watches">
+                                    Coach Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-351">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/guess-watches">
+                                    Guess Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-353">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/daniel-wellington-watches">
+                                    Daniel Wellington Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-22">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/citizen-watches">
+                                    Citizen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-850">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/quantum-watches">
+                                    Quantum Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-903">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/cerruti-watches">
+                                    Cerruti Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-142 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessible-desirable-brands">
+                                    Accessible & Desirable Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-watches">
+                                    Fastrack Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/qnq-watches">
+                                    Q&Q Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-64">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sonata-watches">
+                                    Sonata Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-318">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/horo-watches">
+                                    Horo Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-852">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tickid-watches">
+                                    Tickid Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-27">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/timex-watches">
+                                    Timex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-122">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/westar-watches">
+                                    Westar Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zoop-watches">
+                                    Zoop Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-119">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/helix-watches">
+                                    Helix Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-41 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-watches">
+                                    Casio Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-247">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sheen-watches">
+                                    Sheen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-248">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/baby-g-watches">
+                                    Baby-G Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-250">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/youth-watches">
+                                    Youth Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-252">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/outdoor-watches">
+                                    Outdoor Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-266">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/enticer-watches">
+                                    Enticer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-253">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watches">
+                                    Smart Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-267">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/protrek-watches">
+                                    Protrek Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-268">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/vintage-watches">
+                                    Vintage Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-281">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/g-shock-watches">
+                                    G-Shock Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-282">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/edifice-watches">
+                                    Edifice Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-26">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-watches">
+                                    Titan Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-904">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-watches">
+                                    Jack & Jill Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-842 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watch-brands">
+                                    Smart Watch Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-320">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/firebolt-watches">
+                                    Firebolt Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-302">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-watches">
+                                    Mi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-315">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/beetel-watches">
+                                    Beetel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-341">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/techlog-watches">
+                                    TechLog Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-345">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/boat-watches">
+                                    Boat Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-348">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/amazfit-watches">
+                                    Amazfit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-845">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/just-corseca-watches">
+                                    Just Corseca Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-men">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/product-catalogue/mens-watches">
+                                    Men                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-women">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/product-catalogue/womens-watches">
+                                    Women                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturers menu-item-manufacturers menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/manufacturers">
+                                    All brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-44">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/alba">
+                                    Alba                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-192">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/amazfit">
+                                    Amazfit                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-172">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/anne-klein">
+                                    Anne Klein                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-130">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/armani-exchange">
+                                    Armani Exchange                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-218">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/aston-martin">
+                                    Aston Martin                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/balmain">
+                                    Balmain                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-169">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/beetel">
+                                    Beetel                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-187">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/boat">
+                                    Boat                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-15">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/calvin-klein">
+                                    Calvin Klein                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/casio">
+                                    Casio                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-208">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/cerruti">
+                                    Cerruti                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-8">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/citizen">
+                                    Citizen                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-186">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/coach">
+                                    Coach                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-199">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/d-time">
+                                    D Time                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-195">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/daniel-wellington">
+                                    Daniel Wellington                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-5">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/diesel">
+                                    Diesel                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-173">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/earnshaw">
+                                    Earnshaw                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-11">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/emporio-armani">
+                                    Emporio Armani                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-14">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/esprit">
+                                    Esprit                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-6">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/fastrack">
+                                    Fastrack                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-170">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/firebolt">
+                                    Firebolt                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-211">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/foce">
+                                    Foce                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-159">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/fossil">
+                                    Fossil                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-182">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/franck-muller">
+                                    Franck Muller                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-200">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/gc">
+                                    GC                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-137">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/giordano">
+                                    Giordano                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-194">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/guess">
+                                    Guess                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/helix">
+                                    Helix                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-167">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/horo">
+                                    Horo                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-196">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/hugo-boss">
+                                    Hugo Boss                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-217">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/hugo-boss-watch">
+                                    Hugo Boss Watch                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-210">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/jack-jill">
+                                    Jack & Jill                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-213">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/jean-fendi">
+                                    Jean Fendi                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-198">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/just-corseca">
+                                    Just Corseca                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-147">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/kenneth-cole">
+                                    Kenneth Cole                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-40">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/longines">
+                                    Longines                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-126">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/mi">
+                                    Mi                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-144">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/michael-kors">
+                                    Michael Kors                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-197">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/movado">
+                                    Movado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-162">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/mq">
+                                    MQ                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-161">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/obaku">
+                                    Obaku                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-219">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/off-road">
+                                    Off Road                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/omega">
+                                    Omega                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/opal">
+                                    Opal                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-212">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/paul-design">
+                                    Paul Design                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-9">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/police">
+                                    Police                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-20">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/qq">
+                                    Q&Q                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-202">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/quantum">
+                                    Quantum                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-2">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rado">
+                                    Rado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-79">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rhythm">
+                                    Rhythm                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-214">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/rock-revival">
+                                    Rock Revival                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-158">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sage">
+                                    Sage                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-7">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/seiko">
+                                    Seiko                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-215">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/seven-friday">
+                                    Seven Friday                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-176">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sevenfriday">
+                                    SevenFriday                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-45">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/skagen">
+                                    Skagen                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-171">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/skin">
+                                    Skin                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-30">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/sonata">
+                                    Sonata                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-175">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/strand">
+                                    Strand                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-16">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/swatch">
+                                    Swatch                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tag-heuer">
+                                    Tag Heuer                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-185">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/techlog">
+                                    TechLog                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-204">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tickid">
+                                    Tickid                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/timex">
+                                    Timex                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-17">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tissot">
+                                    Tissot                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-12">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/titan">
+                                    Titan                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-10">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tommy-hilfiger">
+                                    Tommy Hilfiger                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-216">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/tornado">
+                                    Tornado                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-28">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/victorinox">
+                                    Victorinox                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-87">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/westar">
+                                    Westar                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-209">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/x-hour">
+                                    X-Hour                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-207">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/zippo">
+                                    Zippo                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-manufacturer menu-item-manufacturer-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/manufacturer/zoop">
+                                    Zoop                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-3 menu-item-has-children">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/products">
+                                    Products                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-8 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/clocks">
+                                    Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-916">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/d-time-clocks">
+                                    D Time Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-854 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/wall-clocks">
+                                    Wall Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-121">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rhythm-clocks">
+                                    Rhythm Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-150">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-clocks">
+                                    Seiko Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-249">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-clocks">
+                                    Casio Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-37">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/opal-clocks">
+                                    Opal Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-905">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/x-hour-clocks">
+                                    X-Hour Clocks                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-855 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/grand-father-clocks">
+                                    Grand Father Clocks                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-846">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/d-time-grand-father-clocks">
+                                    D Time Grand Father Clocks                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-294">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mq-grand-father-clocks">
+                                    Mq Grand Father Clocks                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-12 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/watches">
+                                    Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-140 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/luxury-brands">
+                                    Luxury & Premium Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-72">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/balmain-watches">
+                                    Balmain Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-354">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/movado-watches">
+                                    Movado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-21">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/seiko-watches">
+                                    Seiko Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-74">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/longines-watches">
+                                    Longines Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-73">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/omega-watches">
+                                    Omega Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-13">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rado-watches">
+                                    Rado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-68">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tag-heuer-watches">
+                                    Tag Heuer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-33">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tissot-watches">
+                                    Tissot Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-47">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-watches">
+                                    Victorinox Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-113">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rolex-watches">
+                                    Rolex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-327">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sevenfriday-watches">
+                                    SevenFriday Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-337">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/franck-muller-watches">
+                                    Franck Muller Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-848">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/gc-watches">
+                                    Gc Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-137 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fashion-brands">
+                                    Fashion Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-116">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/armani-exchange-watches">
+                                    Armani Exchange Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-355">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/hugo-boss-watches">
+                                    Hugo Boss Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-34">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calvin-klein-watches">
+                                    Calvin Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-18">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/diesel-watches">
+                                    Diesel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-915">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tornado-watches">
+                                    Tornado Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-918">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/aston-martin-watches">
+                                    Aston Martin Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-920">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/off-road-watches">
+                                    Off Road Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-25">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/emporio-armani-watches">
+                                    Emporio Armani Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-913">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/rock-revival-watches">
+                                    Rock Revival Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-917">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jean-fendi-watches">
+                                    Jean Fendi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-910">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/foce-watches">
+                                    Foce Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-32">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/esprit-watches">
+                                    Esprit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-148">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/giordano-watches">
+                                    Giordano Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-183">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-watches">
+                                    Kenneth Cole Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-149">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/michael-kors-watches">
+                                    Michael Kors Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-23">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/police-watches">
+                                    Police Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-107">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skagen-watches">
+                                    Skagen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-35">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/swatch-watches">
+                                    Swatch Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-24">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tommy-hilfiger-watches">
+                                    Tommy Hilfiger Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-256">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-watches">
+                                    Fossil Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-101">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/alba-watches">
+                                    Alba Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-262">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/obaku-watches">
+                                    Obaku Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-323">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/anne-klein-watches">
+                                    Anne Klein Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-324">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/earnshaw-watches">
+                                    Earnshaw Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-326">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/strand-watches">
+                                    Strand Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-342">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/coach-watches">
+                                    Coach Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-351">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/guess-watches">
+                                    Guess Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-353">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/daniel-wellington-watches">
+                                    Daniel Wellington Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-22">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/citizen-watches">
+                                    Citizen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-850">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/quantum-watches">
+                                    Quantum Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-903">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/cerruti-watches">
+                                    Cerruti Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-142 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessible-desirable-brands">
+                                    Accessible & Desirable Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-19">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-watches">
+                                    Fastrack Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-39">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/qnq-watches">
+                                    Q&Q Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-64">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sonata-watches">
+                                    Sonata Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-318">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/horo-watches">
+                                    Horo Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-852">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/tickid-watches">
+                                    Tickid Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-27">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/timex-watches">
+                                    Timex Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-122">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/westar-watches">
+                                    Westar Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-38">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zoop-watches">
+                                    Zoop Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-119">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/helix-watches">
+                                    Helix Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-41 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-watches">
+                                    Casio Watches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-247">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sheen-watches">
+                                    Sheen Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-248">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/baby-g-watches">
+                                    Baby-G Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-250">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/youth-watches">
+                                    Youth Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-252">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/outdoor-watches">
+                                    Outdoor Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-266">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/enticer-watches">
+                                    Enticer Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-253">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watches">
+                                    Smart Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-267">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/protrek-watches">
+                                    Protrek Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-268">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/vintage-watches">
+                                    Vintage Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-281">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/g-shock-watches">
+                                    G-Shock Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-282">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/edifice-watches">
+                                    Edifice Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-26">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-watches">
+                                    Titan Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-904">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-watches">
+                                    Jack & Jill Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-842 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/smart-watch-brands">
+                                    Smart Watch Brands                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-320">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/firebolt-watches">
+                                    Firebolt Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-302">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-watches">
+                                    Mi Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-315">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/beetel-watches">
+                                    Beetel Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-341">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/techlog-watches">
+                                    TechLog Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-345">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/boat-watches">
+                                    Boat Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-348">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/amazfit-watches">
+                                    Amazfit Watches                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-845">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/just-corseca-watches">
+                                    Just Corseca Watches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-151 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/stopwatches">
+                                    Stopwatches                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-283">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-stopwatches">
+                                    Casio Stopwatches                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-187 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/accessories">
+                                    Accessories                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-194 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/belts">
+                                    Belts                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-851">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-belts">
+                                    Titan Belts                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-844">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-belts">
+                                    Fossil Belts                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-199 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/wallets">
+                                    Wallets                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-908">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/titan-wallets">
+                                    Titan Wallets                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-356">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fossil-wallets">
+                                    Fossil Wallets                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-310 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/sunglasses">
+                                    Sunglasses                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-311">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-sunglasses">
+                                    Fastrack Sunglasses                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-312">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/mi-sunglasses">
+                                    Mi Sunglasses                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-919">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/jack-jill-sunglasses">
+                                    Jack & Jill Sunglasses                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-316">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-accessories">
+                                    Fastrack Accessories                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-856">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/fastrack-bags">
+                                    Fastrack Bags                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-907">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/victorinox-knifes">
+                                    Victorinox Knifes                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-321 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/perfumes">
+                                    Perfumes                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-322">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/skin-perfumes">
+                                    Skin Perfumes                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-330">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/kenneth-cole-accessories">
+                                    Kenneth Cole Accessories                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-862">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/zippo-lighters">
+                                    Zippo Lighters                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-911">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/paul-design-watch-winders">
+                                    Paul Design Watch Winders                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-category menu-item-category-258 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/electronics">
+                                    Electronics                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-260 menu-item-has-children">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/calculators">
+                                    Calculators                                    <span class="sub-arrow fas fa-angle-down" aria-hidden="true"></span>
+                                </a>
+                        <ul class="sub-menu elementor-nav--dropdown">
+		                    <li class="menu-item menu-item-type-category menu-item-category-160">
+                <a class="elementor-sub-item" href="https://www.swisstimehouse.com/casio-calculator">
+                                    Casio Calculator                                </a>
+                            </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+        		        </ul>
+                    </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-top-deals-offers">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/prices-drop">
+                                    Top Deals & Offers                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-instagram-store">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/instagram-store">
+                                    Instagram Store                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-141">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/our-stores">
+                                    Our Stores                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-140">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/about-us">
+                                    About us                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-cms-page menu-item-cms-page-138">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/careers">
+                                    Careers                                </a>
+                            </li>
+                    <li class="menu-item menu-item-type-link menu-item-lnk-my-account">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/login?back=my-account">
+                                    My Account                                </a>
+                            </li>
+        		
+        <li class="rolex_menu">
+          <div>
+          <a href="https://www.swisstimehouse.com/content/rolex" style="display: block;padding: 5px 0px;">
+            <span style="display: inline-block;    position: relative;
+    width: 150px;
+    height: 70px;" class="rolex-retailer-clock mob_rolex"></span>
+          </a>
+          </div>
+
+        </li>
+              </ul>
+        </nav>
+        </div>        </div>
+                <div class="elementor-element elementor-element-2304c245 elementor-search--skin-topbar elementor-widget__width-auto search1 elementor-widget elementor-widget-ajax-search" data-id="2304c245" data-element_type="widget" data-settings="{&quot;skin&quot;:&quot;topbar&quot;,&quot;list_limit&quot;:10,&quot;show_image&quot;:&quot;yes&quot;,&quot;show_category&quot;:&quot;yes&quot;,&quot;show_price&quot;:&quot;yes&quot;}" data-widget_type="ajax-search.default">
+        <div class="elementor-widget-container">        <form class="elementor-search" role="search" action="https://www.swisstimehouse.com/search" method="get">
+                            <div class="elementor-search__toggle" role="button" tabindex="0" aria-label="Search" aria-controls="elementor-search__container-2304c245" aria-expanded="false">
+                <i aria-hidden="true" class="ceicon ceicon-search-glint"></i>            </div>
+                    <div class="elementor-search__container" id="elementor-search__container-2304c245" role="dialog" aria-labelledby="elementor-search__label-2304c245">
+                            <div class="elementor-search__label" id="elementor-search__label-2304c245">What are you looking for?</div>
+                <div class="elementor-search__input-wrapper">
+                            <input class="elementor-search__input" type="search" name="s" placeholder="Search our catalog" value="" minlength="2" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list">
+                            <div class="elementor-search__icon elementor-search__clear" aria-hidden="true"><i class="ceicon-close"></i></div>
+                                        </div>
+                <div class="dialog-lightbox-close-button" role="button" tabindex="0" aria-label="Close">
+                    <i class="ceicon-close" aria-hidden="true"></i>
+                </div>
+                        </div>
+        </form>
+        </div>        </div>
+                <div class="elementor-element elementor-element-f7b52cd elementor-widget__width-auto elementor-cart--empty-indicator-hide shopping-cart1 elementor-cart--items-indicator-bubble elementor-cart--show-shipping-yes elementor-cart--show-view-cart-yes elementor-cart--show-checkout-yes elementor-cart--buttons-inline elementor-widget elementor-widget-shopping-cart" data-id="f7b52cd" data-element_type="widget" data-settings="{&quot;modal_url&quot;:&quot;https:\/\/www.swisstimehouse.com\/module\/creativeelements\/ajax&quot;,&quot;labels&quot;:{&quot;gift&quot;:&quot;Gift&quot;,&quot;facetLabelFacetValue&quot;:&quot;%facet_label%: %facet_value%&quot;,&quot;productDetails&quot;:&quot;Product Details&quot;,&quot;regularPrice&quot;:&quot;Regular price&quot;,&quot;removeFromCart&quot;:&quot;remove from cart&quot;},&quot;action_open_cart&quot;:&quot;yes&quot;,&quot;action_show_modal&quot;:&quot;yes&quot;,&quot;remove_item_icon&quot;:{&quot;value&quot;:&quot;far fa-circle-xmark&quot;,&quot;library&quot;:&quot;fa-regular&quot;}}" data-widget_type="shopping-cart.default">
+        <div class="elementor-widget-container">            <dialog class="elementor-cart__container elementor-lightbox" id="elementor-cart__dialog-f7b52cd" aria-modal="true" aria-labelledby="elementor-cart__title-f7b52cd">
+                <div class="elementor-cart__main">
+                    <a class="elementor-cart__close-button ceicon-close" href="javascript://close" role="button" aria-label="Close"></a>
+                    <div class="elementor-cart__title" id="elementor-cart__title-f7b52cd">
+                        Your Shopping Cart                    </div>
+                            <div class="elementor-cart__empty-message" role="alert" aria-live="polite">No products in the cart.</div>
+        <div class="elementor-cart__products ce-scrollbar-y--auto" role="list">
+                    </div>
+        <div class="elementor-cart__summary" role="list" aria-label="Your order">
+            <div class="elementor-cart__summary-label" role="term">0 items</div>
+            <div class="elementor-cart__summary-value" role="definition">₹ 0</div>
+                    <span class="elementor-cart__summary-label" role="term">Shipping</span>
+            <span class="elementor-cart__summary-value" role="definition"></span>
+            <strong class="elementor-cart__summary-label" role="term">Total</strong>
+            <strong class="elementor-cart__summary-value" role="definition">₹ 0</strong>
+        </div>
+        <div class="elementor-alert elementor-alert-warning" hidden role="alert" aria-live="polite">
+            <span class="elementor-alert-description"></span>
+        </div>
+        <footer class="elementor-cart__footer-buttons">
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-button--cart elementor-size-md">
+                    <span class="elementor-button-text">View Cart</span>
+                </a>
+            </div>
+            <div class="elementor-align-justify">
+                <a href="https://www.swisstimehouse.com/order" class="elementor-button elementor-button--checkout elementor-size-md"tabindex="-1" aria-disabled="true">
+                    <span class="elementor-button-text">Checkout</span>
+                </a>
+            </div>
+        </footer>
+        <!--<div class="snap_emi_txt"></div>
+<span class="snapmint_lowest_emi_value" style="display:none;" 
+      data-snapmint-price="0" 
+      data-snapmint-merchant_id="" 
+      data-snapmint-page="checkout_page"></span>
+	  --->                </div>
+            </dialog>        <div class="elementor-cart__toggle">
+            <a href="https://www.swisstimehouse.com/cart?action=show" class="elementor-button elementor-size-sm" role="button" aria-label="Shopping Cart" aria-controls="elementor-cart__dialog-f7b52cd" aria-expanded="false" aria-description="0 items">
+                <span class="elementor-button-icon" data-counter="0" aria-hidden="true">
+                    <i class="ceicon ceicon-cart-medium"></i>                </span>
+                <span class="elementor-button-text">₹ 0</span>
+            </a>
+        </div>
+        </div>        </div>
+                <div class="elementor-element elementor-element-8392c98 elementor-widget__width-auto otp_login elementor-nav--align-center elementor-widget elementor-widget-sign-in elementor-widget-nav-menu" data-id="8392c98" data-element_type="widget" data-settings="{&quot;align_submenu&quot;:&quot;right&quot;,&quot;submenu_icon&quot;:{&quot;value&quot;:&quot;&quot;,&quot;library&quot;:&quot;&quot;},&quot;layout&quot;:&quot;horizontal&quot;,&quot;show_submenu_on&quot;:&quot;hover&quot;}" data-widget_type="sign-in.default">
+        <div class="elementor-widget-container">        <nav class="ce-user-menu elementor-nav--main elementor-nav__container elementor-nav--layout-horizontal" aria-label="User Menu">        <ul class="elementor-nav" id="usermenu-8392c98" role="none">
+                    <li class="menu-item menu-item-type-account menu-item-account-0">
+                <a class="elementor-item" href="https://www.swisstimehouse.com/my-account" aria-label="My account">
+                    <i class="ceicon ceicon-user-o"></i>                                                </a>
+                            </li>
+                </ul>
+        </nav>
+        </div>        </div>
+                <div class="elementor-element elementor-element-3dc6de38 elementor-widget__width-auto elementor-widget elementor-widget-ps-widget-module" data-id="3dc6de38" data-element_type="widget" data-widget_type="ps-widget-module.default">
+        <div class="elementor-widget-container"><!-- whatsappchat -->
+</div>        </div>
+                <div class="elementor-element elementor-element-f3e2ec8 elementor-widget-mobile__width-auto elementor-widget elementor-widget-html" data-id="f3e2ec8" data-element_type="widget" data-widget_type="html.default">
+        <div class="elementor-widget-container"><div style="text-align: right;">
+    <img class="chatbase-clone-button-mobile" src="https://backend.chatbase.co/storage/v1/object/public/chat-icons/034638ea-1510-464d-ab08-ddbf9415756f/9aYxyeB8gJrt1_7U9MRGL.jpg" alt="Chat" style="width: 38px; height: 38px; border-radius: 50%; cursor: pointer;">
+</div>
+</div>        </div>
+                        </div>
+            </div>
+        </div>
+                        </div>
+            </div>
+        </section>
+                    </div>
+        </div>
+          <div
+  class="wishlist-add-to"
+  data-url="https://www.swisstimehouse.com/module/blockwishlist/action?action=getAllWishlist"
+>
+  <div
+    class="wishlist-modal modal fade"
+    
+      :class="{show: !isHidden}"
+    
+    tabindex="-1"
+    role="dialog"
+    aria-modal="true"
+  >
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">
+            Add to wishlist
+          </h5>
+          <button
+            type="button"
+            class="close"
+            @click="toggleModal"
+            data-dismiss="modal"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <choose-list
+            @hide="toggleModal"
+            :product-id="productId"
+            :product-attribute-id="productAttributeId"
+            :quantity="quantity"
+            url="https://www.swisstimehouse.com/module/blockwishlist/action?action=getAllWishlist"
+            add-url="https://www.swisstimehouse.com/module/blockwishlist/action?action=addProductToWishlist"
+            empty-text="No list found."
+          ></choose-list>
+        </div>
+
+        <div class="modal-footer">
+          <a @click="openNewWishlistModal" class="wishlist-add-to-new text-primary">
+            <i class="material-icons">add_circle_outline</i> Create new list
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div 
+    class="modal-backdrop fade"
+    
+      :class="{in: !isHidden}"
+    
+  >
+  </div>
+</div>
+
+
+  <div
+  class="wishlist-create"
+  data-url="https://www.swisstimehouse.com/module/blockwishlist/action?action=createNewWishlist"
+  data-title="Create wishlist"
+  data-label="Wishlist name"
+  data-placeholder="Add name"
+  data-cancel-text="Cancel"
+  data-create-text="Create wishlist"
+  data-length-text="List title is too short"
+>
+  <div
+    class="wishlist-modal modal fade"
+    
+      :class="{show: !isHidden}"
+    
+    tabindex="-1"
+    role="dialog"
+    aria-modal="true"
+  >
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">((title))</h5>
+          <button
+            type="button"
+            class="close"
+            @click="toggleModal"
+            data-dismiss="modal"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group form-group-lg">
+            <label class="form-control-label" for="input2">((label))</label>
+            <input
+              type="text"
+              class="form-control form-control-lg"
+              v-model="value"
+              id="input2"
+              :placeholder="placeholder"
+            />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="modal-cancel btn btn-secondary"
+            data-dismiss="modal"
+            @click="toggleModal"
+          >
+            ((cancelText))
+          </button>
+
+          <button
+            type="button"
+            class="btn btn-primary"
+            @click="createWishlist"
+          >
+            ((createText))
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div 
+    class="modal-backdrop fade"
+    
+      :class="{in: !isHidden}"
+    
+  >
+  </div>
+</div>
+
+  <div
+  class="wishlist-login"
+  data-login-text="Sign in"
+  data-cancel-text="Cancel"
+>
+  <div
+    class="wishlist-modal modal fade"
+    
+      :class="{show: !isHidden}"
+    
+    tabindex="-1"
+    role="dialog"
+    aria-modal="true"
+  >
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Sign in</h5>
+          <button
+            type="button"
+            class="close"
+            @click="toggleModal"
+            data-dismiss="modal"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p class="modal-text">You need to be logged in to save products in your wishlist.</p>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="modal-cancel btn btn-secondary"
+            data-dismiss="modal"
+            @click="toggleModal"
+          >
+            ((cancelText))
+          </button>
+
+          <a
+            type="button"
+            class="btn btn-primary"
+            :href="prestashop.urls.pages.authentication"
+          >
+            ((loginText))
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div
+    class="modal-backdrop fade"
+    
+      :class="{in: !isHidden}"
+    
+  >
+  </div>
+</div>
+
+  <div
+    class="wishlist-toast"
+    data-rename-wishlist-text="Wishlist name modified!"
+    data-added-wishlist-text="Product added to wishlist!"
+    data-create-wishlist-text="Wishlist created!"
+    data-delete-wishlist-text="Wishlist deleted!"
+    data-copy-text="Share link copied!"
+    data-delete-product-text="Product deleted!"
+  ></div>
+
+			
+		</footer>
+	</main>
+	
+				
+
+
+
+
+	<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="https://www.swisstimehouse.com/themes/core.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon-child/assets/js/swipervendor.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/otplogin/views/js/script.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon-child/assets/js/theme.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ps_emailsubscription/views/js/ps_emailsubscription.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon/modules/ps_emailalerts/js/mailalerts.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/creativeelements/views/lib/swiper/swiper.min.js?v=11.2.10" ></script>
+	<script src="https://www.swisstimehouse.com/modules/creativeelements/views/lib/smartmenus/jquery.smartmenus.min.js?v=1.2.1" ></script>
+	<script src="https://www.swisstimehouse.com/modules/creativeelements/views/js/frontend-modules.min.js?v=2.14.0" ></script>
+	<script src="https://www.swisstimehouse.com/modules/creativeelements/views/lib/sticky/jquery.sticky.min.js?v=2.14.0" ></script>
+	<script src="https://www.swisstimehouse.com/modules/creativeelements/views/js/frontend.min.js?v=2.14.0" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ps_facebook/views/js/front/conversion-api.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/cashondeliveryfeeplus//views/js/front.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/steasycheckout/views/js/socail_login.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/steasycheckout/views/js/md5.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/quantitydiscountpro/views/js/qdp.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/trackdelhivery//views/js/front.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/trackbluedart//views/js/front.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/r_stars.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/spmgsnipreview.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/jquery.fileupload.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/jquery.fileupload-process.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/jquery.fileupload-validate.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/main-fileupload.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/users.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/storereviews.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/owl.carousel.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/spmgsnipreview/views/js/jquery.scrollTo.min.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/storelocator/views/js/jquery.easy-autocomplete.min.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/storelocator/views/js/store_cal.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ybc_instagram/views/js/ets.fancybox.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ybc_instagram/views/js/isotope.pkgd.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ybc_instagram/views/js/ets.lazy.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ybc_instagram/views/js/instagram.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/ybc_instagram/views/js/slick.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/hioutofstocknotification/views/js/front.js" ></script>
+	<script src="https://www.swisstimehouse.com/js/jquery/ui/jquery-ui.min.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/rcpgtagmanager/views/js/hook/eventsClient.bundle.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/blockwishlist/public/product.bundle.js" ></script>
+	<script src="https://www.swisstimehouse.com/js/jquery/plugins/fancybox/jquery.fancybox.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/callforprice/views/js/callforprice.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/iqitmegamenu/views/js/front.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/storelocator/views/js/stores_17.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/blockwishlist/public/graphql.js" ></script>
+	<script src="https://www.swisstimehouse.com/modules/blockwishlist/public/vendors.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon-child/assets/js/product.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon/assets/js/custom.js" ></script>
+	<script src="https://www.swisstimehouse.com/themes/falcon/modules/ambjolisearch/views/js/ambjolisearch.js" ></script>
+	<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD_PuoIlhGD1qX38nJtWpz6_wvjETtthP4&amp;loading=async&amp;libraries=places" ></script>
+
+
+	
+	
+		<script id="js-rcpgtm-data" type="application/json">{"detail_products_list":[],"order_products_list":[],"order_complete_data":[],"order_context_user_data":[],"detail_product_view":[{"id_product":125701,"id_attribute":0,"id_lang":1,"id_category":281,"category_path":["Home","Products","Watches","Accessible & Desirable Brands","Casio Watches","G-Shock Watches"],"name":"Casio G1714 - GM-B2100SD-1CDR G-Shock Watch","attributes":[],"id_manufacturer":21,"manufacturer_name":"Casio","price_sale":34997,"price_sale_tax_excl":34997,"price_main":49995,"price_main_tax_excl":49995,"is_available":true,"condition":"new","ean":"4549526401541","isbn":"","mpn":"","upc":"","reference":"G1714"}]}</script>
+
+	
+</body>
+</html>

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -115,3 +115,98 @@ def test_dispatch_returns_error_for_unknown_tool():
 
     result = dispatch("nonexistent_tool", {})
     assert "unknown tool" in result.lower()
+
+
+_CASIO_WATCH = {"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0}
+
+
+def test_add_watch_asks_for_target_when_missing(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch("bot.functions.fetch_swisstimehouse", return_value=_CASIO_WATCH)
+    mock_db = mocker.patch("bot.functions.db_add_watch")
+    result = add_watch("https://www.swisstimehouse.com/casio-g1714")
+    assert "34997" in result
+    assert "target" in result.lower()
+    mock_db.assert_not_called()
+
+
+def test_add_watch_stores_with_target(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch("bot.functions.fetch_swisstimehouse", return_value=_CASIO_WATCH)
+    mock_db = mocker.patch(
+        "bot.functions.db_add_watch", return_value={"id": "w1", "name": "Casio G1714"}
+    )
+    result = add_watch("https://www.swisstimehouse.com/casio-g1714", target_price=30000.0)
+    assert "Casio G1714" in result
+    assert "30000" in result
+    mock_db.assert_called_once_with(
+        name="Casio G1714",
+        brand="Casio",
+        reference_no="G1714",
+        target_price=30000.0,
+        swisstimehouse_url="https://www.swisstimehouse.com/casio-g1714",
+    )
+
+
+def test_add_watch_fetch_failure(mocker):
+    from bot.functions import add_watch
+
+    mocker.patch("bot.functions.fetch_swisstimehouse", return_value=None)
+    result = add_watch("https://www.swisstimehouse.com/bad", target_price=30000.0)
+    assert (
+        "couldn't" in result.lower()
+        or "could not" in result.lower()
+        or "unable" in result.lower()
+    )
+
+
+def test_list_watches_with_rows(mocker):
+    from bot.functions import list_watches
+
+    mocker.patch(
+        "bot.functions.db_get_watches",
+        return_value=[{"name": "Casio G1714", "target_price": 30000.0}],
+    )
+    result = list_watches()
+    assert "Casio G1714" in result
+    assert "30000" in result
+
+
+def test_list_watches_empty(mocker):
+    from bot.functions import list_watches
+
+    mocker.patch("bot.functions.db_get_watches", return_value=[])
+    result = list_watches()
+    assert "empty" in result.lower() or "no watches" in result.lower()
+
+
+def test_set_watch_target_success(mocker):
+    from bot.functions import set_watch_target
+
+    mocker.patch("bot.functions.db_set_watch_target", return_value=True)
+    result = set_watch_target("Casio G1714", 25000.0)
+    assert "25000" in result
+
+
+def test_remove_watch_success(mocker):
+    from bot.functions import remove_watch
+
+    mocker.patch("bot.functions.db_remove_watch", return_value=True)
+    result = remove_watch("Casio G1714")
+    assert "no longer" in result.lower() or "removed" in result.lower()
+
+
+def test_dispatch_routes_to_add_watch(mocker):
+    from bot.functions import dispatch
+
+    mocker.patch("bot.functions.fetch_swisstimehouse", return_value=_CASIO_WATCH)
+    mocker.patch(
+        "bot.functions.db_add_watch", return_value={"id": "w1", "name": "Casio G1714"}
+    )
+    result = dispatch(
+        "add_watch",
+        {"url": "https://www.swisstimehouse.com/casio-g1714", "target_price": 30000.0},
+    )
+    assert "Casio G1714" in result

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -210,3 +210,26 @@ def test_dispatch_routes_to_add_watch(mocker):
         {"url": "https://www.swisstimehouse.com/casio-g1714", "target_price": 30000.0},
     )
     assert "Casio G1714" in result
+
+
+def test_get_watch_price_not_found(mocker):
+    from bot.functions import get_watch_price
+
+    mocker.patch("bot.functions.db_find_watch_by_name", return_value=None)
+    result = get_watch_price("Unknown Watch")
+    assert "isn't on your watch list" in result.lower() or "not" in result.lower()
+
+
+def test_get_watch_price_success(mocker):
+    from bot.functions import get_watch_price
+
+    mocker.patch(
+        "bot.functions.db_find_watch_by_name",
+        return_value={"name": "Casio G1714", "swisstimehouse_url": "https://www.swisstimehouse.com/casio-g1714"},
+    )
+    mocker.patch(
+        "bot.functions.fetch_swisstimehouse",
+        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 33000.0},  # noqa: E501
+    )
+    result = get_watch_price("casio g1714")
+    assert "33000" in result

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -229,7 +229,10 @@ def test_get_watch_price_success(mocker):
     )
     mocker.patch(
         "bot.functions.fetch_swisstimehouse",
-        return_value={"name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 33000.0},  # noqa: E501
+        return_value={
+            "name": "Casio G1714", "brand": "Casio",
+            "reference": "G1714", "price": 33000.0,
+        },
     )
     result = get_watch_price("casio g1714")
     assert "33000" in result

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -219,3 +219,20 @@ def test_run_checks_watches_too(mocker):
 
     run()
     mock_process_watch.assert_called_once_with({"id": "w1", "name": "Casio G1714"})
+
+
+def test_process_watch_handles_missing_url(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    sample_watch = {**sample_watch, "swisstimehouse_url": None}
+    mock_fetch = mocker.patch("cron.price_check.fetch_swisstimehouse")
+    mock_hist = mocker.patch("cron.price_check.insert_watch_price_history")
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+
+    mock_fetch.assert_not_called()
+    mock_hist.assert_called_once_with(
+        watch_id="watch-uuid-1", swisstimehouse_price=None, myntra_price=None
+    )
+    mock_alert.assert_not_called()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -109,6 +109,7 @@ def test_run_checks_all_games(mocker):
             {"id": "2", "title": "Game B", "itad_id": "bbb"},
         ],
     )
+    mocker.patch("cron.price_check.get_watches", return_value=[])
     mock_process = mocker.patch("cron.price_check.process_game")
 
     run()
@@ -116,3 +117,105 @@ def test_run_checks_all_games(mocker):
     assert mock_process.call_count == 2
     mock_process.assert_any_call({"id": "1", "title": "Game A", "itad_id": "aaa"})
     mock_process.assert_any_call({"id": "2", "title": "Game B", "itad_id": "bbb"})
+
+
+@pytest.fixture
+def sample_watch():
+    return {
+        "id": "watch-uuid-1",
+        "name": "Casio G1714",
+        "target_price": 30000.0,
+        "swisstimehouse_url": "https://www.swisstimehouse.com/casio-g1714",
+        "myntra_url": None,
+    }
+
+
+def test_process_watch_sends_alert_below_target(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={
+            "name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 29000.0
+        },
+    )
+    mock_hist = mocker.patch("cron.price_check.insert_watch_price_history")
+    mocker.patch("cron.price_check.get_last_watch_notified_price", return_value=None)
+    mock_provider = MagicMock()
+    mock_provider.generate_text.return_value = "Buy now!"
+    mocker.patch("cron.price_check.get_provider", return_value=mock_provider)
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+    mock_log = mocker.patch("cron.price_check.log_watch_notification")
+
+    process_watch(sample_watch)
+
+    mock_hist.assert_called_once_with(
+        watch_id="watch-uuid-1", swisstimehouse_price=29000.0, myntra_price=None
+    )
+    mock_alert.assert_called_once()
+    _, kwargs = mock_alert.call_args
+    assert kwargs["watch_name"] == "Casio G1714"
+    assert kwargs["price"] == 29000.0
+    assert kwargs["seller"] == "Swiss Time House"
+    mock_log.assert_called_once_with("watch-uuid-1", 29000.0, "Swiss Time House")
+
+
+def test_process_watch_skips_above_target(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={
+            "name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 34997.0
+        },
+    )
+    mocker.patch("cron.price_check.insert_watch_price_history")
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_alert.assert_not_called()
+
+
+def test_process_watch_skips_when_not_lower_than_last_notified(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch(
+        "cron.price_check.fetch_swisstimehouse",
+        return_value={
+            "name": "Casio G1714", "brand": "Casio", "reference": "G1714", "price": 29000.0
+        },
+    )
+    mocker.patch("cron.price_check.insert_watch_price_history")
+    mocker.patch("cron.price_check.get_last_watch_notified_price", return_value=29000.0)
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_alert.assert_not_called()
+
+
+def test_process_watch_skips_when_no_price(sample_watch, mocker):
+    from cron.price_check import process_watch
+
+    mocker.patch("cron.price_check.fetch_swisstimehouse", return_value=None)
+    mock_hist = mocker.patch("cron.price_check.insert_watch_price_history")
+    mock_alert = mocker.patch("cron.price_check.send_watch_alert")
+
+    process_watch(sample_watch)
+    mock_hist.assert_called_once_with(
+        watch_id="watch-uuid-1", swisstimehouse_price=None, myntra_price=None
+    )
+    mock_alert.assert_not_called()
+
+
+def test_run_checks_watches_too(mocker):
+    from cron.price_check import run
+
+    mocker.patch("cron.price_check.get_games", return_value=[])
+    mocker.patch(
+        "cron.price_check.get_watches",
+        return_value=[{"id": "w1", "name": "Casio G1714"}],
+    )
+    mock_process_watch = mocker.patch("cron.price_check.process_watch")
+
+    run()
+    mock_process_watch.assert_called_once_with({"id": "w1", "name": "Casio G1714"})

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -324,3 +324,19 @@ def test_get_last_watch_notified_price(mocker):
     mocker.patch.object(client, "_get_client", return_value=mock_supa)
 
     assert client.get_last_watch_notified_price("w1") == 28000.0
+
+
+def test_log_watch_notification(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    fake_table.insert.return_value.execute.return_value.data = [
+        {"id": "n1", "watch_id": "w1", "price": 29000.0, "seller": "Swiss Time House"}
+    ]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    result = client.log_watch_notification("w1", 29000.0, "Swiss Time House")
+    assert result["id"] == "n1"
+    args, _ = fake_table.insert.call_args
+    assert args[0]["seller"] == "Swiss Time House"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -242,3 +242,85 @@ def test_summarize_if_needed_triggers_and_deletes(mocker):
     mock_client.table("chat_summary").upsert.assert_called_once()
     ids = [f"id{i}" for i in range(15)]
     mock_client.table("chat_messages").delete.return_value.in_.assert_called_once_with("id", ids)
+
+
+def test_add_watch_upserts(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    fake_table.upsert.return_value.execute.return_value.data = [
+        {"id": "w1", "name": "Casio G1714"}
+    ]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    result = client.add_watch(
+        name="Casio G1714", brand="Casio", reference_no="G1714",
+        target_price=30000.0, swisstimehouse_url="https://www.swisstimehouse.com/casio-g1714",
+    )
+    assert result["id"] == "w1"
+    fake_table.upsert.assert_called_once()
+    args, kwargs = fake_table.upsert.call_args
+    assert kwargs.get("on_conflict") == "swisstimehouse_url"
+    assert args[0]["target_price"] == 30000.0
+
+
+def test_get_watches_returns_rows(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    fake_table.select.return_value.execute.return_value.data = [
+        {"id": "w1", "name": "Casio G1714"}
+    ]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    rows = client.get_watches()
+    assert rows == [{"id": "w1", "name": "Casio G1714"}]
+
+
+def test_set_watch_target_updates_match(mocker):
+    from db import client
+
+    mocker.patch.object(
+        client, "get_watches", return_value=[{"id": "w1", "name": "Casio G1714"}]
+    )
+    fake_table = mocker.MagicMock()
+    fake_table.update.return_value.eq.return_value.execute.return_value.data = [{"id": "w1"}]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    assert client.set_watch_target("casio g1714", 25000.0) is True
+
+
+def test_set_watch_target_no_match(mocker):
+    from db import client
+
+    mocker.patch.object(client, "get_watches", return_value=[])
+    assert client.set_watch_target("nonexistent", 25000.0) is False
+
+
+def test_remove_watch_deletes_match(mocker):
+    from db import client
+
+    mocker.patch.object(
+        client, "get_watches", return_value=[{"id": "w1", "name": "Casio G1714"}]
+    )
+    fake_table = mocker.MagicMock()
+    fake_table.delete.return_value.eq.return_value.execute.return_value.data = [{"id": "w1"}]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    assert client.remove_watch("Casio G1714") is True
+
+
+def test_get_last_watch_notified_price(mocker):
+    from db import client
+
+    fake_table = mocker.MagicMock()
+    chain = fake_table.select.return_value.eq.return_value.order.return_value.limit.return_value
+    chain.execute.return_value.data = [{"price": 28000}]
+    mock_supa = mocker.MagicMock(table=lambda *_: fake_table)
+    mocker.patch.object(client, "_get_client", return_value=mock_supa)
+
+    assert client.get_last_watch_notified_price("w1") == 28000.0

--- a/tests/test_discord_webhook.py
+++ b/tests/test_discord_webhook.py
@@ -34,3 +34,26 @@ def test_send_deal_alert_raises_when_webhook_url_missing(monkeypatch):
     with patch("utils.discord.load_dotenv"):
         with pytest.raises(EnvironmentError, match="DISCORD_WEBHOOK_URL"):
             send_deal_alert("Game", 9.99, 19.99, "GOG", 50, "Great deal.")
+
+
+def test_send_watch_alert_posts_message(mocker, monkeypatch):
+    from utils import discord
+
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.test/webhook")
+    mock_post = mocker.patch("utils.discord.requests.post")
+    mock_post.return_value.raise_for_status.return_value = None
+
+    discord.send_watch_alert(
+        watch_name="Casio G1714",
+        price=29000.0,
+        seller="Swiss Time House",
+        target_price=30000.0,
+        ai_commentary="Great time to buy.",
+    )
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    body = kwargs["json"]["content"]
+    assert "Casio G1714" in body
+    assert "29000" in body
+    assert "Swiss Time House" in body

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -100,3 +100,27 @@ def test_fetch_swisstimehouse_returns_none_on_unparseable_price():
     with patch("utils.watches.cloudscraper.create_scraper", return_value=mock_scraper):
         result = fetch_swisstimehouse("https://www.swisstimehouse.com/weird")
     assert result is None
+
+
+def test_fetch_swisstimehouse_skips_product_without_name():
+    from utils.watches import fetch_swisstimehouse
+
+    # First Product has a price but no name (must be skipped); second is valid.
+    html = '''
+    <html><head>
+    <script type="application/ld+json">
+    {"@type": "Product", "sku": "X", "offers": {"price": "100"}}
+    </script>
+    <script type="application/ld+json">
+    {"@type": "Product", "name": "Casio Named", "sku": "G42",
+     "brand": "Casio", "offers": {"price": "5000"}}
+    </script>
+    </head><body></body></html>
+    '''
+    scraper = _mock_scraper_returning(html)
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/x")
+
+    assert result is not None
+    assert result["name"] == "Casio Named"
+    assert result["price"] == 5000.0

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -57,3 +57,46 @@ def test_fetch_swisstimehouse_returns_none_on_request_error():
     with patch("utils.watches.cloudscraper.create_scraper", return_value=scraper):
         result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
     assert result is None
+
+
+def test_fetch_swisstimehouse_handles_string_brand_and_skips_empty_price():
+    from utils.watches import fetch_swisstimehouse
+
+    # First Product has an empty-string price (must be skipped); second is valid
+    # with a bare-string brand and a list-form @type.
+    html = '''
+    <html><head>
+    <script type="application/ld+json">
+    {"@type": "Product", "name": "Bad", "sku": "X", "offers": {"price": ""}}
+    </script>
+    <script type="application/ld+json">
+    {"@type": ["Product", "Thing"], "name": "Casio Good", "sku": "G999",
+     "brand": "Casio", "offers": {"price": "12345", "priceCurrency": "INR"}}
+    </script>
+    </head><body></body></html>
+    '''
+    mock_scraper = _mock_scraper_returning(html)
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=mock_scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-good")
+
+    assert result is not None
+    assert result["name"] == "Casio Good"
+    assert result["brand"] == "Casio"
+    assert result["reference"] == "G999"
+    assert result["price"] == 12345.0
+
+
+def test_fetch_swisstimehouse_returns_none_on_unparseable_price():
+    from utils.watches import fetch_swisstimehouse
+
+    html = '''
+    <html><head>
+    <script type="application/ld+json">
+    {"@type": "Product", "name": "Weird", "sku": "Z", "offers": {"price": "not-a-number"}}
+    </script>
+    </head><body></body></html>
+    '''
+    mock_scraper = _mock_scraper_returning(html)
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=mock_scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/weird")
+    assert result is None

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -1,0 +1,59 @@
+# tests/test_watches.py
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+FIXTURE = Path(__file__).parent / "fixtures" / "swisstimehouse_casio_g1714.html"
+
+
+def _mock_scraper_returning(html: str):
+    """Build a fake cloudscraper whose .get(...) returns a response with .text=html."""
+    response = MagicMock()
+    response.text = html
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    scraper = MagicMock()
+    scraper.get.return_value = response
+    return scraper
+
+
+def test_fetch_swisstimehouse_parses_jsonld():
+    from utils.watches import fetch_swisstimehouse
+
+    html = FIXTURE.read_text()
+    mock_scraper = _mock_scraper_returning(html)
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=mock_scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+
+    assert result is not None
+    assert result["brand"] == "Casio"
+    assert result["reference"] == "G1714"
+    assert "Casio" in result["name"]
+    assert result["price"] == 34997.0
+    assert isinstance(result["price"], float)
+
+
+def test_fetch_swisstimehouse_rejects_non_swisstimehouse_url():
+    from utils.watches import fetch_swisstimehouse
+
+    result = fetch_swisstimehouse("https://www.amazon.in/some-watch")
+    assert result is None
+
+
+def test_fetch_swisstimehouse_returns_none_when_no_product_jsonld():
+    from utils.watches import fetch_swisstimehouse
+
+    html = "<html><head><title>nope</title></head><body>no structured data</body></html>"
+    mock_scraper = _mock_scraper_returning(html)
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=mock_scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+    assert result is None
+
+
+def test_fetch_swisstimehouse_returns_none_on_request_error():
+    from utils.watches import fetch_swisstimehouse
+
+    scraper = MagicMock()
+    scraper.get.side_effect = Exception("Cloudflare blocked")
+    with patch("utils.watches.cloudscraper.create_scraper", return_value=scraper):
+        result = fetch_swisstimehouse("https://www.swisstimehouse.com/casio-g1714")
+    assert result is None

--- a/utils/discord.py
+++ b/utils/discord.py
@@ -23,3 +23,23 @@ def send_deal_alert(
     )
     response = requests.post(webhook_url, json={"content": message})
     response.raise_for_status()
+
+
+def send_watch_alert(
+    watch_name: str,
+    price: float,
+    seller: str,
+    target_price: float,
+    ai_commentary: str,
+) -> None:
+    load_dotenv()
+    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL")
+    if not webhook_url:
+        raise EnvironmentError("DISCORD_WEBHOOK_URL is not set. Add it to your .env file.")
+    message = (
+        f"**Watch Deal Alert: {watch_name}**\n"
+        f"₹{price:.2f} on {seller} (target was ₹{target_price:.2f})\n"
+        f"{ai_commentary}"
+    )
+    response = requests.post(webhook_url, json={"content": message})
+    response.raise_for_status()

--- a/utils/watches.py
+++ b/utils/watches.py
@@ -17,8 +17,11 @@ def _is_swisstimehouse(url: str) -> bool:
     return host == _ALLOWED_HOST or host.endswith("." + _ALLOWED_HOST)
 
 
-def _extract_product_jsonld(html: str) -> dict | None:
-    """Return the first schema.org Product JSON-LD object with a price, or None."""
+def _extract_product_offer(html: str) -> tuple[dict, dict] | tuple[None, None]:
+    """Return (product, offers) for the first schema.org Product with a usable price.
+
+    Returns (None, None) if no such Product JSON-LD block is found.
+    """
     soup = BeautifulSoup(html, "html.parser")
     for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
         raw = script.string or script.get_text() or ""
@@ -30,15 +33,18 @@ def _extract_product_jsonld(html: str) -> dict | None:
         for obj in candidates:
             if not isinstance(obj, dict):
                 continue
-            if obj.get("@type") != "Product":
+            obj_type = obj.get("@type")
+            types = obj_type if isinstance(obj_type, list) else [obj_type]
+            if "Product" not in types:
                 continue
             offers = obj.get("offers") or {}
             if isinstance(offers, list):
                 offers = offers[0] if offers else {}
-            if offers.get("price") is None:
+            price = offers.get("price")
+            if price is None or price == "":
                 continue
-            return obj
-    return None
+            return obj, offers
+    return None, None
 
 
 def fetch_swisstimehouse(url: str) -> dict | None:
@@ -59,14 +65,16 @@ def fetch_swisstimehouse(url: str) -> dict | None:
         logger.warning("Failed to fetch swisstimehouse URL %s: %s", url, exc)
         return None
 
-    product = _extract_product_jsonld(html)
+    product, offers = _extract_product_offer(html)
     if product is None:
         logger.warning("No Product JSON-LD with a price found at %s", url)
         return None
 
-    offers = product.get("offers") or {}
-    if isinstance(offers, list):
-        offers = offers[0] if offers else {}
+    try:
+        price = float(offers["price"])
+    except (ValueError, TypeError):
+        logger.warning("Invalid price value at %s: %r", url, offers.get("price"))
+        return None
 
     brand = product.get("brand") or {}
     brand_name = brand.get("name") if isinstance(brand, dict) else brand
@@ -75,13 +83,10 @@ def fetch_swisstimehouse(url: str) -> dict | None:
         "name": product.get("name"),
         "brand": brand_name,
         "reference": product.get("sku") or product.get("mpn"),
-        "price": float(offers["price"]),
+        "price": price,
     }
     logger.info(
         "Fetched %s: %s (ref=%s) ₹%.2f",
-        url,
-        result["name"],
-        result["reference"],
-        result["price"],
+        url, result["name"], result["reference"], result["price"],
     )
     return result

--- a/utils/watches.py
+++ b/utils/watches.py
@@ -37,6 +37,8 @@ def _extract_product_offer(html: str) -> tuple[dict, dict] | tuple[None, None]:
             types = obj_type if isinstance(obj_type, list) else [obj_type]
             if "Product" not in types:
                 continue
+            if not obj.get("name"):
+                continue
             offers = obj.get("offers") or {}
             if isinstance(offers, list):
                 offers = offers[0] if offers else {}

--- a/utils/watches.py
+++ b/utils/watches.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+from urllib.parse import urlparse
+
+import cloudscraper
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger("drophunter.watches")
+
+_ALLOWED_HOST = "swisstimehouse.com"
+
+
+def _is_swisstimehouse(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host == _ALLOWED_HOST or host.endswith("." + _ALLOWED_HOST)
+
+
+def _extract_product_jsonld(html: str) -> dict | None:
+    """Return the first schema.org Product JSON-LD object with a price, or None."""
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = script.string or script.get_text() or ""
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        candidates = data if isinstance(data, list) else [data]
+        for obj in candidates:
+            if not isinstance(obj, dict):
+                continue
+            if obj.get("@type") != "Product":
+                continue
+            offers = obj.get("offers") or {}
+            if isinstance(offers, list):
+                offers = offers[0] if offers else {}
+            if offers.get("price") is None:
+                continue
+            return obj
+    return None
+
+
+def fetch_swisstimehouse(url: str) -> dict | None:
+    """
+    Fetch a swisstimehouse.com product page and parse its schema.org JSON-LD.
+    Returns {name, brand, reference, price} or None on any failure.
+    """
+    if not _is_swisstimehouse(url):
+        logger.warning("Rejecting non-swisstimehouse URL: %s", url)
+        return None
+
+    try:
+        scraper = cloudscraper.create_scraper()
+        response = scraper.get(url, timeout=30)
+        response.raise_for_status()
+        html = response.text
+    except Exception as exc:
+        logger.warning("Failed to fetch swisstimehouse URL %s: %s", url, exc)
+        return None
+
+    product = _extract_product_jsonld(html)
+    if product is None:
+        logger.warning("No Product JSON-LD with a price found at %s", url)
+        return None
+
+    offers = product.get("offers") or {}
+    if isinstance(offers, list):
+        offers = offers[0] if offers else {}
+
+    brand = product.get("brand") or {}
+    brand_name = brand.get("name") if isinstance(brand, dict) else brand
+
+    result = {
+        "name": product.get("name"),
+        "brand": brand_name,
+        "reference": product.get("sku") or product.get("mpn"),
+        "price": float(offers["price"]),
+    }
+    logger.info(
+        "Fetched %s: %s (ref=%s) ₹%.2f",
+        url,
+        result["name"],
+        result["reference"],
+        result["price"],
+    )
+    return result


### PR DESCRIPTION
## Summary

Adds a parallel **watch price tracking** path alongside the existing game tracker. Users add a watch by pasting a [Swiss Time House](https://www.swisstimehouse.com) product URL plus a required target price; a background sweep re-checks the page and fires a Discord alert when the price drops to/below target.

- **`utils/watches.py`** — `fetch_swisstimehouse(url)`: fetches via `cloudscraper` (Swiss Time House is behind Cloudflare; plain `requests` 403s) and parses the page's `schema.org` Product JSON-LD into `{name, brand, reference, price}`, or `None` on any failure.
- **DB** — three new tables (`watches`, `watch_price_history`, `watch_notifications_log`) in `db/schema.sql`; the game tables are untouched. `watch_price_history` carries reserved `myntra_*` columns for a future second source (no migration needed later).
- **`bot/functions.py`** — 5 LLM tools: `add_watch`, `list_watches`, `get_watch_price`, `set_watch_target`, `remove_watch` (registered in `TOOLS` + `_FUNCTION_MAP`).
- **`cron/price_check.py`** — `process_watch` + watch sweep wired into `run()` (lowest available price vs. target, with the same "only re-alert when lower than last notified" dedup as games; missing/blocked source degrades to `None`, never a false alert).
- **`utils/discord.py`** — `send_watch_alert`.
- **`ai/graph.py`** — system prompt extended to describe watch tracking.
- Docs (`README.md`, `CLAUDE.md`) and the design spec/plan updated.

Built spec-first (brainstorm → spec → plan → subagent-driven TDD); each task passed spec + code-quality review.

## Design decisions

- **v1 = Swiss Time House only.** Myntra and official brand sites (e.g. casio.in) are deferred; the schema already accommodates them.
- **Target price is required** for watches (no historical-low fallback like ITAD gives games — we accumulate our own history over time).
- **Deterministic JSON-LD parse**, not LLM extraction — free/fast on every sweep, robust to layout changes.

## Test plan

- [x] `pytest` — full suite green except one **pre-existing** failure (`tests/test_db.py::test_remove_game_deletes_row`) that also fails on `main`, unrelated to this change.
- [x] `ruff check` — new files clean (pre-existing lint in legacy code untouched).
- [x] Live smoke test: `fetch_swisstimehouse('https://www.swisstimehouse.com/casio-g1714')` returns the real product end-to-end past Cloudflare.

## ⚠️ Post-merge / deploy steps (manual)

1. **Apply the new tables to the live Supabase** — they exist only in `db/schema.sql`. Run that DDL in the Supabase SQL editor (PostgREST can't run DDL). The three `create table` statements are in `db/schema.sql`.
2. **Reinstall deps** where the bot + cron run — `cloudscraper` and `beautifulsoup4` were added to `requirements.txt`.

No new environment variables required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)